### PR TITLE
 Accessing from IE11 shows blank page. #162

### DIFF
--- a/Content/Styles/app.css
+++ b/Content/Styles/app.css
@@ -339,3 +339,19 @@ pre {
     left: 50%;
     z-index: 100
 }
+
+#browserSupportOverlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    margin: auto;
+    background-color: darkgrey;
+    color: #ffffff;
+    opacity: 0.90;
+    z-index: 1000;
+    font-size: 25px;
+    text-align: center;
+    vertical-align: middle;
+}

--- a/index.html
+++ b/index.html
@@ -232,6 +232,14 @@
     </div>
     <div id="dark-blocker" class="dark-full-site-blocker" style="display: none"></div>
     <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"></script>
+    <script type="text/javascript">
+        try {
+            eval('"use strict"; class foo {}');
+        } catch (e) {
+            var browserSupportOverlay = jQuery('<div id="browserSupportOverlay"> Your browser is not supported. <br> Please use any of the following browsers: Mozilla Firefox, Google Chrome, Microsoft Edge </div>');
+            browserSupportOverlay.appendTo(document.body);
+        }
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
Resource explorer targets es6. Display an overlay on browsers with no es6 support.
![image](https://user-images.githubusercontent.com/28721598/28287830-ecd6dd1e-6af1-11e7-9c45-6ae0dbeaaa2a.png)
