### PR TITLE
 GET /api/providers takes too long (10s of seconds) for users with la…

### DIFF
--- a/Controllers/ArmRepository.cs
+++ b/Controllers/ArmRepository.cs
@@ -40,7 +40,7 @@ namespace ARMExplorer.Controllers
             return subscriptionIds;
         }
 
-        public async Task<HashSet<string>> GetproviderNamesFor(HttpRequestMessage requestMessage, string subscriptionId)
+        public async Task<HashSet<string>> GetProviderNamesFor(HttpRequestMessage requestMessage, string subscriptionId)
         {
             var response = await GetResourcesForAsync(requestMessage, subscriptionId);
             response.EnsureSuccessStatusCode();

--- a/Controllers/IArmRepository.cs
+++ b/Controllers/IArmRepository.cs
@@ -7,7 +7,7 @@ namespace ARMExplorer.Controllers
     public interface IArmRepository
     {
         Task<IList<string>> GetSubscriptionIdsAsync(HttpRequestMessage requestMessage);
-        Task<HashSet<string>> GetproviderNamesFor(HttpRequestMessage requestMessage, string subscriptionId);
+        Task<HashSet<string>> GetProviderNamesFor(HttpRequestMessage requestMessage, string subscriptionId);
         Task<Dictionary<string, Dictionary<string, HashSet<string>>>> GetProvidersFor(HttpRequestMessage requestMessage, string subscriptionId);
         Task<HttpResponseMessage> InvokeAsync(HttpRequestMessage requestMessage, HttpRequestMessage info);
     }

--- a/Controllers/OperationController.cs
+++ b/Controllers/OperationController.cs
@@ -56,19 +56,45 @@ namespace ARMExplorer.Controllers
             return swaggerSpec;
         }
 
+        private async Task<HashSet<string>> GetProviderNamesFor(HttpRequestMessage requestMessage, string subscriptionId)
+        {
+            try
+            {
+                return await _armRepository.GetProviderNamesFor(requestMessage, subscriptionId);
+            }
+            catch (Exception)
+            {
+                // Return empty set as fallback
+                return new HashSet<string>();
+            }
+        }
+
         [Authorize]
         public async Task<HttpResponseMessage> GetAllProviders()
         {
+            var watch = Stopwatch.StartNew();
             HyakUtils.CSMUrl = HyakUtils.CSMUrl ?? Utils.GetCSMUrl(Request.RequestUri.Host);
 
             var allProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var tasks = new List<Task<HashSet<string>>>();
             foreach (var subscriptionId in await _armRepository.GetSubscriptionIdsAsync(Request))
             {
-                allProviders.UnionWith(await _armRepository.GetproviderNamesFor(Request, subscriptionId));
+                tasks.Add(GetProviderNamesFor(Request, subscriptionId));
             }
+
+            foreach (var hashSet in await Task.WhenAll(tasks))
+            {
+                allProviders.UnionWith(hashSet);
+            }
+
             // This makes the Microsoft.Resources provider show up for any groups that have other resources
             allProviders.Add("MICROSOFT.RESOURCES");
-            return Request.CreateResponse(HttpStatusCode.OK, allProviders);
+
+            watch.Stop();
+
+            var httpResponseMessage = Request.CreateResponse(HttpStatusCode.OK, allProviders);
+            httpResponseMessage.Headers.Add("TimeElapsedMs", watch.ElapsedMilliseconds.ToString());
+            return httpResponseMessage;
         }
 
         [Authorize]

--- a/Tests/WebApiTests/ArmRepositoryTests.cs
+++ b/Tests/WebApiTests/ArmRepositoryTests.cs
@@ -23,7 +23,7 @@ namespace Tests.WebApiTests
         public void TestGetproviderNamesFor()
         {
             var armRepository = new ArmRepository(new MockHttpClientWrapper());
-            var providerNames = armRepository.GetproviderNamesFor(null, "00000000-0000-0000-0000-000000000003").Result;
+            var providerNames = armRepository.GetProviderNamesFor(null, "00000000-0000-0000-0000-000000000003").Result;
             Assert.Equal(10,providerNames.Count);
             HashSet<string> expectedProviderNames = new HashSet<string>{ "MICROSOFT.EVENTHUB", "MICROSOFT.INSIGHTS", "MICROSOFT.KEYVAULT", "MICROSOFT.SQL", "MICROSOFT.STORAGE", "MICROSOFT.WEB", "MICROSOFT.CLASSICCOMPUTE", "MICROSOFT.NETWORK", "MICROSOFT.PORTAL", "MICROSOFT.CLASSICSTORAGE" }; 
             Assert.Equal(expectedProviderNames.Count, providerNames.Count);


### PR DESCRIPTION
…rge number of resourcegroups #160

 Fetch resources in different subscriptions in parallel