### PR TITLE
Updated AAD configuration documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This project has dependencies on OAuth authentication.
 2. Open `ARMExplorer.sln` with VS 2017+ and compile.
 
 ### Create AAD application
-1. Go to [Azure Portal](https://manage.windowsazure.com/) while logged in as an Org ID (i.e. not MSA) and create AAD Application. You may create an application on existing AAD directory or a new directory altogether.
+1. Go to [Azure Portal](https://portal.azure.com/) while logged in as an Org ID (i.e. not MSA) and create AAD Application. You may create an application on existing AAD directory or a new directory altogether.
 1. Select 'Azure Active Directory' and then 'App registrations' and click 'New application registration'
 1. Enter any name for application name.
 1. Select `WEB APPLICATION AND/OR WEB API`

--- a/README.md
+++ b/README.md
@@ -7,13 +7,14 @@ This project has dependencies on OAuth authentication.
 
 ### Create AAD application
 1. Go to [Azure Portal](https://manage.windowsazure.com/) while logged in as an Org ID (i.e. not MSA) and create AAD Application. You may create an application on existing AAD directory or a new directory altogether.
-1. Select `Add an application my organization is developing`
+1. Select 'Azure Active Directory' and then 'App registrations' and click 'New application registration'
 1. Enter any name for application name.
 1. Select `WEB APPLICATION AND/OR WEB API`
-1. Enter `https://localhost:44306/` as `SIGN ON URL`
+1. Enter `https://localhost:44300/` as `SIGN ON URL`
 1. For `APP ID URL`, enter something like `https://davidebboslingshot.onmicrosoft.com/`.
-1. Once created, click `CONFIGURE` tab
-1. On `Permission to other applications`, add `Windows Azure Service Management API` and check `Access Azure Service Management` for `Delegated Permissions` and save.
+1. Once created, click `Settings` tab
+1. On `Required permissions`, add `Windows Azure Service Management API` and check `Access Azure Service Management` for `Delegated Permissions` and save.
+1. In 'Reply URLs' add 'https://localhost:44300/manage'
 
 ### Fix AADClientId and AADClientSecret in codes
 1. Copy `CLIENT ID` and paste it in [this line](https://github.com/projectkudu/ARMExplorer/blob/master/Modules/ARMOAuthModule.cs#L38), replacing `Environment.GetEnvironmentVariable("AADClientId")`.


### PR DESCRIPTION
This PR is to update documentation related to AAD configuration.
When configuring AAD i have noticed some differences between existing description and how the portal actually works, so I guess the instructions were created some time ago and now they are outdated.

In addition, one more step was necessary to make it work:
"In 'Reply URLs' add 'https://localhost:44300/manage'" 