### PR TITLE
Modifying GetResources logic to allow for empty resource arrays with nextLink values

### DIFF
--- a/Controllers/ArmRepository.cs
+++ b/Controllers/ArmRepository.cs
@@ -11,7 +11,7 @@ namespace ARMExplorer.Controllers
     public class ArmRepository : IArmRepository 
     {
         private readonly IHttpClientWrapper _clientWrapper;
-        private readonly int _maxNextLinkDepth = 5;
+        private readonly int _maxNextLinkDepth = 20;
 
         public ArmRepository(IHttpClientWrapper clientWrapper)
         {
@@ -53,11 +53,12 @@ namespace ARMExplorer.Controllers
                 var newResourceFound = AddResourceToList(armResourceListResult.Value, allResources);
 
                 // ARM API returns the same skiptoken and resources repeatedly when there are no more resources. To avoid infinite cycle break when
-                // 1. No new resource was found in the current response or
+                // 1. No new resource was found in the current response and resources were provided (return arrays can be empty with nextLins, see
+                //    issue https://github.com/projectkudu/AzureResourceExplorer/issues/254) or
                 // 2. Limit the max number of links to follow to _maxNextLinkDepth or
                 // 3. When nextLink is empty
 
-                if (!newResourceFound)
+                if (!newResourceFound && armResourceListResult.Value.Count > 0)
                 {
                     break;
                 }


### PR DESCRIPTION
Attempting to resolve #254 and possibly #228.

I increased the number of nextLink requests from 5 to 20 which, in theory, gives us ~2,000 resources returned assuming 100 resources limit per response.

The logic added to GetResources is intended to only break the loop if no new resources were added AND resources were returned from the request. As shown in #254, the requests can return empty arrays with nextLink values indicating responses were filtered out. This causes Azure Resource Explorer to stop querying for resources too early.

It's possible we should increase or remove the nextLink limit as well. I do not know of an instance where the ARM API will return the same skiptoken or duplicate resources when there aren't any. However, as shown in #254, it will return empty arrays when it filters too late in the processing. Perhaps that is what this code was originally intending to ignore?

#228 may not be resolved because listing resources this way may not be enough to get all of the subscriptions someone has access to, but it is a start.