### PR TITLE
Add managed clusters swagger specs to azure resource explorer

### DIFF
--- a/ARMExplorer.csproj
+++ b/ARMExplorer.csproj
@@ -424,6 +424,9 @@
     <Content Include="App_Data\SwaggerSpecs\Microsoft.EventGrid\EventGrid.json" />
     <Content Include="App_Data\SwaggerSpecs\common-types\resource-management\v1\types.json" />
     <Content Include="App_Data\SwaggerSpecs\Microsoft.GuestConfiguration\definitions.json" />
+    <Content Include="App_Data\SwaggerSpecs\Microsoft.ServiceFabricManagedClusters\managedapplication.json" />
+    <Content Include="App_Data\SwaggerSpecs\Microsoft.ServiceFabricManagedClusters\managedcluster.json" />
+    <Content Include="App_Data\SwaggerSpecs\Microsoft.ServiceFabricManagedClusters\nodetype.json" />
     <None Include="Web.Debug.config">
       <DependentUpon>Web.config</DependentUpon>
     </None>

--- a/App_Data/SwaggerSpecs/Microsoft.ServiceFabricManagedClusters/managedapplication.json
+++ b/App_Data/SwaggerSpecs/Microsoft.ServiceFabricManagedClusters/managedapplication.json
@@ -1,0 +1,2688 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "ServiceFabricManagementClient",
+    "description": "Azure Service Fabric Resource Provider API Client",
+    "version": "2021-05-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      },
+      "type": "oauth2"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applicationTypes/{applicationTypeName}": {
+      "get": {
+        "tags": [
+          "ApplicationType"
+        ],
+        "operationId": "ApplicationTypes_Get",
+        "summary": "Gets a Service Fabric managed application type name resource.",
+        "description": "Get a Service Fabric application type name resource created or in the process of being created in the Service Fabric managed cluster resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Get an application type": {
+            "$ref": "./examples/ApplicationTypeNameGetOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ApplicationType"
+        ],
+        "operationId": "ApplicationTypes_CreateOrUpdate",
+        "summary": "Creates or updates a Service Fabric managed application type name resource.",
+        "description": "Create or update a Service Fabric managed application type name resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The application type name resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeResource"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Put an application type": {
+            "$ref": "./examples/ApplicationTypeNamePutOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "ApplicationType"
+        ],
+        "operationId": "ApplicationTypes_Update",
+        "summary": "Updates the tags of an application type resource of a given managed cluster.",
+        "description": "Updates the tags of an application type resource of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The application type resource updated tags.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeUpdateParameters"
+            }
+          }
+        ],
+        "x-ms-examples": {
+          "Patch an application type": {
+            "$ref": "./examples/ApplicationTypeNamePatchOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ApplicationType"
+        ],
+        "operationId": "ApplicationTypes_Delete",
+        "summary": "Deletes a Service Fabric managed application type name resource.",
+        "description": "Delete a Service Fabric managed application type name resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete an application type": {
+            "$ref": "./examples/ApplicationTypeNameDeleteOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The resource was not found."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applicationTypes": {
+      "get": {
+        "tags": [
+          "ApplicationType"
+        ],
+        "operationId": "ApplicationTypes_List",
+        "summary": "Gets the list of application type name resources created in the specified Service Fabric managed cluster resource.",
+        "description": "Gets all application type name resources created or in the process of being created in the Service Fabric managed cluster resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get a list of application type name resources": {
+            "$ref": "./examples/ApplicationTypeNameListOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeResourceList"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applicationTypes/{applicationTypeName}/versions/{version}": {
+      "get": {
+        "tags": [
+          "ApplicationTypeVersion"
+        ],
+        "operationId": "ApplicationTypeVersions_Get",
+        "summary": "Gets a Service Fabric managed application type version resource.",
+        "description": "Get a Service Fabric managed application type version resource created or in the process of being created in the Service Fabric managed application type name resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/version"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Get an application type version": {
+            "$ref": "./examples/ApplicationTypeVersionGetOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ApplicationTypeVersion"
+        ],
+        "operationId": "ApplicationTypeVersions_CreateOrUpdate",
+        "summary": "Creates or updates a Service Fabric managed application type version resource.",
+        "description": "Create or update a Service Fabric managed application type version resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/version"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The application type version resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionResource"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Put an application type version": {
+            "$ref": "./examples/ApplicationTypeVersionPutOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionResource"
+            }
+          },
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "ApplicationTypeVersion"
+        ],
+        "operationId": "ApplicationTypeVersions_Update",
+        "summary": "Updates the tags of an application type version resource of a given managed cluster.",
+        "description": "Updates the tags of an application type version resource of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/version"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The application type version resource updated tags.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionUpdateParameters"
+            }
+          }
+        ],
+        "x-ms-examples": {
+          "Patch an application type version": {
+            "$ref": "./examples/ApplicationTypeVersionPatchOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ApplicationTypeVersion"
+        ],
+        "operationId": "ApplicationTypeVersions_Delete",
+        "summary": "Deletes a Service Fabric managed application type version resource.",
+        "description": "Delete a Service Fabric managed application type version resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/version"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete an application type version": {
+            "$ref": "./examples/ApplicationTypeVersionDeleteOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The resource was not found."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applicationTypes/{applicationTypeName}/versions": {
+      "get": {
+        "tags": [
+          "ApplicationTypeVersion"
+        ],
+        "operationId": "ApplicationTypeVersions_ListByApplicationTypes",
+        "summary": "Gets the list of application type version resources created in the specified Service Fabric managed application type name resource.",
+        "description": "Gets all application type version resources created or in the process of being created in the Service Fabric managed application type name resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationTypeName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get a list of application type version resources": {
+            "$ref": "./examples/ApplicationTypeVersionListOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationTypeVersionResourceList"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applications/{applicationName}": {
+      "get": {
+        "tags": [
+          "Application"
+        ],
+        "operationId": "Applications_Get",
+        "summary": "Gets a Service Fabric managed application resource.",
+        "description": "Get a Service Fabric managed application resource created or in the process of being created in the Service Fabric cluster resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Get an application": {
+            "$ref": "./examples/ApplicationGetOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Application"
+        ],
+        "operationId": "Applications_CreateOrUpdate",
+        "summary": "Creates or updates a Service Fabric managed application resource.",
+        "description": "Create or update a Service Fabric managed application resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The application resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationResource"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Put an application with minimum parameters": {
+            "$ref": "./examples/ApplicationPutOperation_example_min.json"
+          },
+          "Put an application with maximum parameters": {
+            "$ref": "./examples/ApplicationPutOperation_example_max.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationResource"
+            }
+          },
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Application"
+        ],
+        "operationId": "Applications_Update",
+        "summary": "Updates the tags of an application resource of a given managed cluster.",
+        "description": "Updates the tags of an application resource of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The application resource updated tags.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ApplicationUpdateParameters"
+            }
+          }
+        ],
+        "x-ms-examples": {
+          "Patch an application": {
+            "$ref": "./examples/ApplicationPatchOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Application"
+        ],
+        "operationId": "Applications_Delete",
+        "summary": "Deletes a Service Fabric managed application resource.",
+        "description": "Delete a Service Fabric managed application resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete an application": {
+            "$ref": "./examples/ApplicationDeleteOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The resource was not found."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applications": {
+      "get": {
+        "tags": [
+          "Application"
+        ],
+        "operationId": "Applications_List",
+        "summary": "Gets the list of managed application resources created in the specified Service Fabric cluster resource.",
+        "description": "Gets all managed application resources created or in the process of being created in the Service Fabric cluster resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "Get a list of application resources": {
+            "$ref": "./examples/ApplicationListOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ApplicationResourceList"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applications/{applicationName}/services/{serviceName}": {
+      "get": {
+        "tags": [
+          "Service"
+        ],
+        "operationId": "Services_Get",
+        "summary": "Gets a Service Fabric managed service resource.",
+        "description": "Get a Service Fabric service resource created or in the process of being created in the Service Fabric managed application resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/serviceName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Get a service": {
+            "$ref": "./examples/ServiceGetOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "Service"
+        ],
+        "operationId": "Services_CreateOrUpdate",
+        "summary": "Creates or updates a Service Fabric managed service resource.",
+        "description": "Create or update a Service Fabric managed service resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/serviceName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The service resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceResource"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Put a service with minimum parameters": {
+            "$ref": "./examples/ServicePutOperation_example_min.json"
+          },
+          "Put a service with maximum parameters": {
+            "$ref": "./examples/ServicePutOperation_example_max.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceResource"
+            }
+          },
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/ServiceResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "Services"
+        ],
+        "operationId": "Services_Update",
+        "summary": "Updates the tags of a service resource of a given managed cluster.",
+        "description": "Updates the tags of a service resource of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/serviceName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The service resource updated tags.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ServiceUpdateParameters"
+            }
+          }
+        ],
+        "x-ms-examples": {
+          "Patch a service": {
+            "$ref": "./examples/ServicePatchOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceResource"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "Service"
+        ],
+        "operationId": "Services_Delete",
+        "summary": "Deletes a Service Fabric managed service resource.",
+        "description": "Delete a Service Fabric managed service resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/serviceName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete a service": {
+            "$ref": "./examples/ServiceDeleteOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The resource was not found."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedclusters/{clusterName}/applications/{applicationName}/services": {
+      "get": {
+        "tags": [
+          "Service"
+        ],
+        "operationId": "Services_ListByApplications",
+        "summary": "Gets the list of service resources created in the specified Service Fabric managed application resource.",
+        "description": "Gets all service resources created or in the process of being created in the Service Fabric managed application resource.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/applicationName"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Get a list of service resources": {
+            "$ref": "./examples/ServiceListOperation_example.json"
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ServiceResourceList"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "AddRemoveIncrementalNamedPartitionScalingMechanism": {
+      "description": "Represents a scaling mechanism for adding or removing named partitions of a stateless service. Partition names are in the format '0','1'...'N-1'.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScalingMechanism"
+        },
+        {
+          "type": "object",
+          "description": "AddRemoveIncrementalNamedPartitionScalingMechanism"
+        }
+      ],
+      "x-ms-discriminator-value": "AddRemoveIncrementalNamedPartition",
+      "required": [
+        "minPartitionCount",
+        "maxPartitionCount",
+        "scaleIncrement"
+      ],
+      "properties": {
+        "minPartitionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of named partitions of the service."
+        },
+        "maxPartitionCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of named partitions of the service."
+        },
+        "scaleIncrement": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of instances to add or remove during a scaling operation."
+        }
+      }
+    },
+    "ApplicationHealthPolicy": {
+      "type": "object",
+      "description": "Defines a health policy used to evaluate the health of an application or one of its children entities.\n",
+      "required": [
+        "considerWarningAsError",
+        "maxPercentUnhealthyDeployedApplications"
+      ],
+      "properties": {
+        "considerWarningAsError": {
+          "type": "boolean",
+          "description": "Indicates whether warnings are treated with the same severity as errors."
+        },
+        "maxPercentUnhealthyDeployedApplications": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum allowed percentage of unhealthy deployed applications. Allowed values are Byte values from zero to 100.\nThe percentage represents the maximum tolerated percentage of deployed applications that can be unhealthy before the application is considered in error.\nThis is calculated by dividing the number of unhealthy deployed applications over the number of nodes where the application is currently deployed on in the cluster.\nThe computation rounds up to tolerate one failure on small numbers of nodes. Default percentage is zero.\n"
+        },
+        "defaultServiceTypeHealthPolicy": {
+          "$ref": "#/definitions/ServiceTypeHealthPolicy",
+          "description": "The health policy used by default to evaluate the health of a service type."
+        },
+        "serviceTypeHealthPolicyMap": {
+          "$ref": "#/definitions/ServiceTypeHealthPolicyMap",
+          "description": "The map with service type health policy per service type name. The map is empty by default."
+        }
+      }
+    },
+    "ApplicationParameterList": {
+      "type": "object",
+      "description": "List of application parameters with overridden values from their default values specified in the application manifest.",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "ApplicationResource": {
+      "description": "The application resource.",
+      "properties": {
+        "identity": {
+          "$ref": "#/definitions/ManagedIdentity"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationResourceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ApplicationResourceList": {
+      "description": "The list of application resources.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of application list results if there are any.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationResourceProperties": {
+      "description": "The application resource properties.",
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The current deployment or provisioning state, which only appears in the response"
+        },
+        "version": {
+          "$ref": "#/definitions/ApplicationTypeVersion"
+        },
+        "parameters": {
+          "$ref": "#/definitions/ApplicationParameterList"
+        },
+        "upgradePolicy": {
+          "$ref": "#/definitions/ApplicationUpgradePolicy"
+        },
+        "managedIdentities": {
+          "description": "List of user assigned identities for the application, each mapped to a friendly name.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationUserAssignedIdentity"
+          }
+        }
+      }
+    },
+    "ApplicationTypeResource": {
+      "description": "The application type name resource",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationTypeResourceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ApplicationTypeResourceList": {
+      "description": "The list of application type names.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationTypeResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of application type list results if there are any.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationTypeResourceProperties": {
+      "description": "The application type name properties",
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The current deployment or provisioning state, which only appears in the response."
+        }
+      }
+    },
+    "ApplicationTypeUpdateParameters": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Application type update parameters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Application type update request"
+    },
+    "ApplicationTypeVersion": {
+      "type": "string",
+      "description": "The version of the application type as defined in the application manifest.\nThis name must be the full Arm Resource ID for the referenced application type version.\n"
+    },
+    "ApplicationTypeVersionResource": {
+      "description": "An application type version resource for the specified application type name resource.",
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ApplicationTypeVersionResourceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ApplicationTypeVersionResourceList": {
+      "description": "The list of application type version resources for the specified application type name resource.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ApplicationTypeVersionResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of application type version list results if there are any.",
+          "readOnly": true
+        }
+      }
+    },
+    "ApplicationTypeVersionResourceProperties": {
+      "description": "The properties of the application type version resource.",
+      "required": [
+        "appPackageUrl"
+      ],
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The current deployment or provisioning state, which only appears in the response"
+        },
+        "appPackageUrl": {
+          "type": "string",
+          "description": "The URL to the application package"
+        }
+      }
+    },
+    "ApplicationTypeVersionUpdateParameters": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Application type version update parameters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Application type version update request"
+    },
+    "ApplicationUpdateParameters": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Application update parameters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Application update request"
+    },
+    "ApplicationUpgradePolicy": {
+      "description": "Describes the policy for a monitored application upgrade.",
+      "properties": {
+        "applicationHealthPolicy": {
+          "$ref": "#/definitions/ApplicationHealthPolicy"
+        },
+        "forceRestart": {
+          "$ref": "#/definitions/ForceRestart"
+        },
+        "rollingUpgradeMonitoringPolicy": {
+          "$ref": "#/definitions/RollingUpgradeMonitoringPolicy"
+        },
+        "instanceCloseDelayDuration": {
+          "type": "integer",
+          "format": "int64",
+          "description": "Duration in seconds, to wait before a stateless instance is closed, to allow the active requests to drain gracefully. This would be effective when the instance is closing during the application/cluster upgrade, only for those instances which have a non-zero delay duration configured in the service description."
+        },
+        "upgradeMode": {
+          "$ref": "#/definitions/RollingUpgradeMode"
+        },
+        "upgradeReplicaSetCheckTimeout": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The maximum amount of time to block processing of an upgrade domain and prevent loss of availability when there are unexpected issues. When this timeout expires, processing of the upgrade domain will proceed regardless of availability loss issues. The timeout is reset at the start of each upgrade domain. Valid values are between 0 and 42949672925 inclusive. (unsigned 32-bit integer)."
+        },
+        "recreateApplication": {
+          "type": "boolean",
+          "description": "Determines whether the application should be recreated on update. If value=true, the rest of the upgrade policy parameters are not allowed."
+        }
+      }
+    },
+    "ApplicationUserAssignedIdentity": {
+      "required": [
+        "name",
+        "principalId"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The friendly name of user assigned identity."
+        },
+        "principalId": {
+          "type": "string",
+          "description": "The principal id of user assigned identity."
+        }
+      }
+    },
+    "AveragePartitionLoadScalingTrigger": {
+      "description": "Represents a scaling trigger related to an average load of a metric/resource of a partition.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScalingTrigger"
+        },
+        {
+          "type": "object",
+          "description": "AveragePartitionLoadScalingTrigger"
+        }
+      ],
+      "x-ms-discriminator-value": "AveragePartitionLoadTrigger",
+      "required": [
+        "metricName",
+        "lowerLoadThreshold",
+        "upperLoadThreshold",
+        "scaleInterval"
+      ],
+      "properties": {
+        "metricName": {
+          "type": "string",
+          "description": "The name of the metric for which usage should be tracked."
+        },
+        "lowerLoadThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "The lower limit of the load below which a scale in operation should be performed."
+        },
+        "upperLoadThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "The upper limit of the load beyond which a scale out operation should be performed."
+        },
+        "scaleInterval": {
+          "type": "string",
+          "description": "The period in seconds on which a decision is made whether to scale or not. This property should come in ISO 8601 format \"hh:mm:ss\"."
+        }
+      }
+    },
+    "AverageServiceLoadScalingTrigger": {
+      "description": "Represents a scaling policy related to an average load of a metric/resource of a service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScalingTrigger"
+        },
+        {
+          "type": "object",
+          "description": "AverageServiceLoadScalingTrigger"
+        }
+      ],
+      "x-ms-discriminator-value": "AverageServiceLoadTrigger",
+      "required": [
+        "metricName",
+        "lowerLoadThreshold",
+        "upperLoadThreshold",
+        "scaleInterval",
+        "useOnlyPrimaryLoad"
+      ],
+      "properties": {
+        "metricName": {
+          "type": "string",
+          "description": "The name of the metric for which usage should be tracked."
+        },
+        "lowerLoadThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "The lower limit of the load below which a scale in operation should be performed."
+        },
+        "upperLoadThreshold": {
+          "type": "number",
+          "format": "double",
+          "description": "The upper limit of the load beyond which a scale out operation should be performed."
+        },
+        "scaleInterval": {
+          "type": "string",
+          "description": "The period in seconds on which a decision is made whether to scale or not. This property should come in ISO 8601 format \"hh:mm:ss\"."
+        },
+        "useOnlyPrimaryLoad": {
+          "type": "boolean",
+          "description": "Flag determines whether only the load of primary replica should be considered for scaling. If set to true, then trigger will only consider the load of primary replicas of stateful service. If set to false, trigger will consider load of all replicas. This parameter cannot be set to true for stateless service."
+        }
+      }
+    },
+    "CorrelationSchemeList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ServiceCorrelation"
+      },
+      "description": "A list that describes the correlation of the service with other services."
+    },
+    "ForceRestart": {
+      "type": "boolean",
+      "description": "If true, then processes are forcefully restarted during upgrade even when the code version has not changed (the upgrade only changes configuration or data).",
+      "default": false
+    },
+    "HealthCheckRetryTimeout": {
+      "type": "string",
+      "description": "The amount of time to retry health evaluation when the application or cluster is unhealthy before FailureAction is executed. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
+    },
+    "HealthCheckStableDuration": {
+      "type": "string",
+      "description": "The amount of time that the application or cluster must remain healthy before the upgrade proceeds to the next upgrade domain. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
+    },
+    "HealthCheckWaitDuration": {
+      "type": "string",
+      "description": "The amount of time to wait after completing an upgrade domain before applying health policies. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
+    },
+    "ManagedIdentity": {
+      "description": "Describes the managed identities for an Azure resource.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The principal id of the managed identity. This property will only be provided for a system assigned identity."
+        },
+        "tenantId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The tenant id of the managed identity. This property will only be provided for a system assigned identity."
+        },
+        "type": {
+          "$ref": "#/definitions/ManagedIdentityType"
+        },
+        "userAssignedIdentities": {
+          "$ref": "#/definitions/UserAssignedIdentityMap"
+        }
+      }
+    },
+    "ManagedIdentityType": {
+      "type": "string",
+      "description": "The type of managed identity for the resource.",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedIdentityType",
+        "modelAsString": false,
+        "values": [
+          {
+            "value": "None",
+            "description": "Indicates that no identity is associated with the resource."
+          },
+          {
+            "value": "SystemAssigned",
+            "description": "Indicates that system assigned identity is associated with the resource."
+          },
+          {
+            "value": "UserAssigned",
+            "description": "Indicates that user assigned identity is associated with the resource."
+          },
+          {
+            "value": "SystemAssigned, UserAssigned",
+            "description": "Indicates that both system assigned and user assigned identity are associated with the resource."
+          }
+        ]
+      }
+    },
+    "MoveCost": {
+      "type": "string",
+      "description": "Specifies the move cost for the service.",
+      "enum": [
+        "Zero",
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "MoveCost",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Zero",
+            "description": "Zero move cost. This value is zero."
+          },
+          {
+            "value": "Low",
+            "description": "Specifies the move cost of the service as Low. The value is 1."
+          },
+          {
+            "value": "Medium",
+            "description": "Specifies the move cost of the service as Medium. The value is 2."
+          },
+          {
+            "value": "High",
+            "description": "Specifies the move cost of the service as High. The value is 3."
+          }
+        ]
+      }
+    },
+    "NamedPartitionScheme": {
+      "description": "Describes the named partition scheme of the service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Partition"
+        },
+        {
+          "type": "object",
+          "description": "NamedPartitionScheme"
+        }
+      ],
+      "x-ms-discriminator-value": "Named",
+      "required": [
+        "names"
+      ],
+      "properties": {
+        "names": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Array for the names of the partitions."
+        }
+      }
+    },
+    "Partition": {
+      "type": "object",
+      "discriminator": "partitionScheme",
+      "description": "Describes how the service is partitioned.",
+      "required": [
+        "partitionScheme"
+      ],
+      "properties": {
+        "partitionScheme": {
+          "$ref": "#/definitions/PartitionScheme",
+          "description": "Specifies how the service is partitioned."
+        }
+      }
+    },
+    "PartitionInstanceCountScaleMechanism": {
+      "description": "Represents a scaling mechanism for adding or removing instances of stateless service partition.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ScalingMechanism"
+        },
+        {
+          "type": "object",
+          "description": "PartitionInstanceCountScaleMechanism"
+        }
+      ],
+      "x-ms-discriminator-value": "ScalePartitionInstanceCount",
+      "required": [
+        "minInstanceCount",
+        "maxInstanceCount",
+        "scaleIncrement"
+      ],
+      "properties": {
+        "minInstanceCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Minimum number of instances of the partition."
+        },
+        "maxInstanceCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Maximum number of instances of the partition."
+        },
+        "scaleIncrement": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of instances to add or remove during a scaling operation."
+        }
+      }
+    },
+    "PartitionScheme": {
+      "type": "string",
+      "description": "Enumerates the ways that a service can be partitioned.",
+      "enum": [
+        "Singleton",
+        "UniformInt64Range",
+        "Named"
+      ],
+      "x-ms-enum": {
+        "name": "PartitionScheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Singleton",
+            "description": "Indicates that the partition is based on string names, and is a SingletonPartitionScheme object, The value is 0."
+          },
+          {
+            "value": "UniformInt64Range",
+            "description": "Indicates that the partition is based on Int64 key ranges, and is a UniformInt64RangePartitionScheme object. The value is 1."
+          },
+          {
+            "value": "Named",
+            "description": "Indicates that the partition is based on string names, and is a NamedPartitionScheme object. The value is 2."
+          }
+        ]
+      }
+    },
+    "ProxyResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure resource identifier.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Azure resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Azure resource type.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location depends on the parent resource.",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Azure resource tags.",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData"
+        }
+      },
+      "description": "The resource model definition for proxy-only resource.",
+      "x-ms-azure-resource": true
+    },
+    "RollingUpgradeMode": {
+      "type": "string",
+      "description": "The mode used to monitor health during a rolling upgrade. The values are Monitored, and UnmonitoredAuto.",
+      "enum": [
+        "Monitored",
+        "UnmonitoredAuto"
+      ],
+      "x-ms-enum": {
+        "name": "RollingUpgradeMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Monitored",
+            "description": "The upgrade will stop after completing each upgrade domain and automatically monitor health before proceeding. The value is 0."
+          },
+          {
+            "value": "UnmonitoredAuto",
+            "description": "The upgrade will proceed automatically without performing any health monitoring. The value is 1."
+          }
+        ]
+      }
+    },
+    "RollingUpgradeMonitoringPolicy": {
+      "description": "The policy used for monitoring the application upgrade",
+      "required": [
+        "failureAction",
+        "healthCheckWaitDuration",
+        "healthCheckStableDuration",
+        "healthCheckRetryTimeout",
+        "upgradeTimeout",
+        "upgradeDomainTimeout"
+      ],
+      "properties": {
+        "failureAction": {
+          "type": "string",
+          "description": "The compensating action to perform when a Monitored upgrade encounters monitoring policy or health policy violations. Invalid indicates the failure action is invalid. Rollback specifies that the upgrade will start rolling back automatically. Manual indicates that the upgrade will switch to UnmonitoredManual upgrade mode.",
+          "enum": [
+            "Rollback",
+            "Manual"
+          ],
+          "x-ms-enum": {
+            "name": "FailureAction",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "Rollback",
+                "description": "Indicates that a rollback of the upgrade will be performed by Service Fabric if the upgrade fails."
+              },
+              {
+                "value": "Manual",
+                "description": "Indicates that a manual repair will need to be performed by the administrator if the upgrade fails. Service Fabric will not proceed to the next upgrade domain automatically."
+              }
+            ]
+          }
+        },
+        "healthCheckWaitDuration": {
+          "$ref": "#/definitions/HealthCheckWaitDuration"
+        },
+        "healthCheckStableDuration": {
+          "$ref": "#/definitions/HealthCheckStableDuration"
+        },
+        "healthCheckRetryTimeout": {
+          "$ref": "#/definitions/HealthCheckRetryTimeout"
+        },
+        "upgradeTimeout": {
+          "$ref": "#/definitions/UpgradeTimeout"
+        },
+        "upgradeDomainTimeout": {
+          "$ref": "#/definitions/UpgradeDomainTimeout"
+        }
+      }
+    },
+    "ScalingMechanism": {
+      "type": "object",
+      "discriminator": "kind",
+      "description": "Describes the mechanism for performing a scaling operation.",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ServiceScalingMechanismKind",
+          "description": "Specifies the mechanism associated with this scaling policy."
+        }
+      }
+    },
+    "ScalingPolicy": {
+      "type": "object",
+      "description": "Specifies a metric to load balance a service during runtime.",
+      "required": [
+        "scalingMechanism",
+        "scalingTrigger"
+      ],
+      "properties": {
+        "scalingMechanism": {
+          "$ref": "#/definitions/ScalingMechanism",
+          "description": "Specifies the mechanism associated with this scaling policy"
+        },
+        "scalingTrigger": {
+          "$ref": "#/definitions/ScalingTrigger",
+          "description": "Specifies the trigger associated with this scaling policy."
+        }
+      }
+    },
+    "ScalingPolicyList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ScalingPolicy"
+      },
+      "description": "Scaling policies for this service."
+    },
+    "ScalingTrigger": {
+      "type": "object",
+      "discriminator": "kind",
+      "description": "Describes the trigger for performing a scaling operation.",
+      "required": [
+        "kind"
+      ],
+      "properties": {
+        "kind": {
+          "$ref": "#/definitions/ServiceScalingTriggerKind",
+          "description": "Specifies the trigger associated with this scaling policy."
+        }
+      }
+    },
+    "ServiceCorrelation": {
+      "type": "object",
+      "description": "Creates a particular correlation between services.",
+      "required": [
+        "scheme",
+        "serviceName"
+      ],
+      "properties": {
+        "scheme": {
+          "$ref": "#/definitions/ServiceCorrelationScheme",
+          "description": "The ServiceCorrelationScheme which describes the relationship between this service and the service specified via ServiceName."
+        },
+        "serviceName": {
+          "$ref": "#/definitions/ServiceName",
+          "description": "The Arm Resource ID of the service that the correlation relationship is established with."
+        }
+      }
+    },
+    "ServiceCorrelationScheme": {
+      "type": "string",
+      "description": "The service correlation scheme.",
+      "enum": [
+        "AlignedAffinity",
+        "NonAlignedAffinity"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceCorrelationScheme",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "AlignedAffinity",
+            "description": "Aligned affinity ensures that the primaries of the partitions of the affinitized services are collocated on the same nodes. This is the default and is the same as selecting the Affinity scheme. The value is 0."
+          },
+          {
+            "value": "NonAlignedAffinity",
+            "description": "Non-Aligned affinity guarantees that all replicas of each service will be placed on the same nodes. Unlike Aligned Affinity, this does not guarantee that replicas of particular role will be collocated. The value is 1."
+          }
+        ]
+      }
+    },
+    "ServiceKind": {
+      "type": "string",
+      "description": "The kind of service (Stateless or Stateful).",
+      "enum": [
+        "Stateless",
+        "Stateful"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Stateless",
+            "description": "Does not use Service Fabric to make its state highly available or reliable. The value is 0."
+          },
+          {
+            "value": "Stateful",
+            "description": "Uses Service Fabric to make its state or part of its state highly available and reliable. The value is 1."
+          }
+        ]
+      }
+    },
+    "ServiceLoadMetric": {
+      "type": "object",
+      "description": "Specifies a metric to load balance a service during runtime.",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the metric. If the service chooses to report load during runtime, the load metric name should match the name that is specified in Name exactly. Note that metric names are case sensitive."
+        },
+        "weight": {
+          "$ref": "#/definitions/ServiceLoadMetricWeight",
+          "description": "The service load metric relative weight, compared to other metrics configured for this service, as a number."
+        },
+        "primaryDefaultLoad": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Used only for Stateful services. The default amount of load, as a number, that this service creates for this metric when it is a Primary replica."
+        },
+        "secondaryDefaultLoad": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Used only for Stateful services. The default amount of load, as a number, that this service creates for this metric when it is a Secondary replica."
+        },
+        "defaultLoad": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Used only for Stateless services. The default amount of load, as a number, that this service creates for this metric."
+        }
+      }
+    },
+    "ServiceLoadMetricsList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ServiceLoadMetric"
+      },
+      "description": "The service load metrics is given as an array of ServiceLoadMetric objects."
+    },
+    "ServiceLoadMetricWeight": {
+      "type": "string",
+      "description": "Determines the metric weight relative to the other metrics that are configured for this service. During runtime, if two metrics end up in conflict, the Cluster Resource Manager prefers the metric with the higher weight.",
+      "enum": [
+        "Zero",
+        "Low",
+        "Medium",
+        "High"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceLoadMetricWeight",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Zero",
+            "description": "Disables resource balancing for this metric. This value is zero."
+          },
+          {
+            "value": "Low",
+            "description": "Specifies the metric weight of the service load as Low. The value is 1."
+          },
+          {
+            "value": "Medium",
+            "description": "Specifies the metric weight of the service load as Medium. The value is 2."
+          },
+          {
+            "value": "High",
+            "description": "Specifies the metric weight of the service load as High. The value is 3."
+          }
+        ]
+      }
+    },
+    "ServiceName": {
+      "type": "string",
+      "description": "The full ARM Resource ID describing the service resource",
+      "x-sf-clientlib": {
+        "typeName": "ServiceName"
+      }
+    },
+    "ServicePlacementInvalidDomainPolicy": {
+      "description": "Describes the policy to be used for placement of a Service Fabric service where a particular fault or upgrade domain should not be used for placement of the instances or replicas of that service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServicePlacementPolicy"
+        },
+        {
+          "type": "object",
+          "description": "ServicePlacementInvalidDomainPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "InvalidDomain",
+      "required": [
+        "domainName"
+      ],
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "The name of the domain that should not be used for placement."
+        }
+      }
+    },
+    "ServicePlacementNonPartiallyPlaceServicePolicy": {
+      "description": "The name of the domain that should used for placement as per this policy.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServicePlacementPolicy"
+        },
+        {
+          "type": "object",
+          "description": "ServicePlacementNonPartiallyPlaceServicePolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "NonPartiallyPlaceService"
+    },
+    "ServicePlacementPoliciesList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ServicePlacementPolicy"
+      },
+      "description": "A list that describes the correlation of the service with other services."
+    },
+    "ServicePlacementPolicy": {
+      "type": "object",
+      "discriminator": "type",
+      "description": "Describes the policy to be used for placement of a Service Fabric service.",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "#/definitions/ServicePlacementPolicyType"
+        }
+      }
+    },
+    "ServicePlacementPolicyType": {
+      "type": "string",
+      "description": "The type of placement policy for a service fabric service. Following are the possible values.",
+      "enum": [
+        "InvalidDomain",
+        "RequiredDomain",
+        "PreferredPrimaryDomain",
+        "RequiredDomainDistribution",
+        "NonPartiallyPlaceService"
+      ],
+      "x-ms-enum": {
+        "name": "ServicePlacementPolicyType",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "InvalidDomain",
+            "description": "Indicates that the ServicePlacementPolicyDescription is of type ServicePlacementInvalidDomainPolicyDescription, which indicates that a particular fault or upgrade domain cannot be used for placement of this service. The value is 0."
+          },
+          {
+            "value": "RequiredDomain",
+            "description": "Indicates that the ServicePlacementPolicyDescription is of type ServicePlacementRequireDomainDistributionPolicyDescription indicating that the replicas of the service must be placed in a specific domain. The value is 1."
+          },
+          {
+            "value": "PreferredPrimaryDomain",
+            "description": "Indicates that the ServicePlacementPolicyDescription is of type ServicePlacementPreferPrimaryDomainPolicyDescription, which indicates that if possible the Primary replica for the partitions of the service should be located in a particular domain as an optimization. The value is 2."
+          },
+          {
+            "value": "RequiredDomainDistribution",
+            "description": "Indicates that the ServicePlacementPolicyDescription is of type ServicePlacementRequireDomainDistributionPolicyDescription, indicating that the system will disallow placement of any two replicas from the same partition in the same domain at any time. The value is 3."
+          },
+          {
+            "value": "NonPartiallyPlaceService",
+            "description": "Indicates that the ServicePlacementPolicyDescription is of type ServicePlacementNonPartiallyPlaceServicePolicyDescription, which indicates that if possible all replicas of a particular partition of the service should be placed atomically. The value is 4."
+          }
+        ]
+      }
+    },
+    "ServicePlacementPreferPrimaryDomainPolicy": {
+      "description": "Describes the policy to be used for placement of a Service Fabric service where the service's \nPrimary replicas should optimally be placed in a particular domain.\n\nThis placement policy is usually used with fault domains in scenarios where the Service Fabric\ncluster is geographically distributed in order to indicate that a service's primary replica should\nbe located in a particular fault domain, which in geo-distributed scenarios usually aligns with regional\nor datacenter boundaries. Note that since this is an optimization it is possible that the Primary replica\nmay not end up located in this domain due to failures, capacity limits, or other constraints.\n",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServicePlacementPolicy"
+        },
+        {
+          "type": "object",
+          "description": "ServicePlacementPreferPrimaryDomainPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "PreferredPrimaryDomain",
+      "required": [
+        "domainName"
+      ],
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "The name of the domain that should used for placement as per this policy."
+        }
+      }
+    },
+    "ServicePlacementRequiredDomainPolicy": {
+      "description": "Describes the policy to be used for placement of a Service Fabric service where the instances or replicas of that service must be placed in a particular domain.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServicePlacementPolicy"
+        },
+        {
+          "type": "object",
+          "description": "ServicePlacementRequiredDomainPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "RequiredDomain",
+      "required": [
+        "domainName"
+      ],
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "The name of the domain that should used for placement as per this policy."
+        }
+      }
+    },
+    "ServicePlacementRequireDomainDistributionPolicy": {
+      "description": "Describes the policy to be used for placement of a Service Fabric service where two replicas\nfrom the same partition should never be placed in the same fault or upgrade domain.\n\nWhile this is not common it can expose the service to an increased risk of concurrent failures\ndue to unplanned outages or other cases of subsequent/concurrent failures. As an example, consider\na case where replicas are deployed across different data center, with one replica per location.\nIn the event that one of the datacenters goes offline, normally the replica that was placed in that\ndatacenter will be packed into one of the remaining datacenters. If this is not desirable then this\npolicy should be set.\n",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServicePlacementPolicy"
+        },
+        {
+          "type": "object",
+          "description": "ServicePlacementRequireDomainDistributionPolicy"
+        }
+      ],
+      "x-ms-discriminator-value": "RequiredDomainDistribution",
+      "required": [
+        "domainName"
+      ],
+      "properties": {
+        "domainName": {
+          "type": "string",
+          "description": "The name of the domain that should used for placement as per this policy."
+        }
+      }
+    },
+    "ServiceResource": {
+      "description": "The service resource.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/ServiceResourceProperties"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/definitions/ProxyResource"
+        }
+      ]
+    },
+    "ServiceResourceList": {
+      "description": "The list of service resources.",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ServiceResource"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of service list results if there are any.",
+          "readOnly": true
+        }
+      }
+    },
+    "ServiceResourceProperties": {
+      "description": "The service resource properties.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServiceResourcePropertiesBase"
+        }
+      ],
+      "required": [
+        "serviceKind",
+        "serviceTypeName",
+        "partitionDescription"
+      ],
+      "discriminator": "serviceKind",
+      "properties": {
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The current deployment or provisioning state, which only appears in the response"
+        },
+        "serviceKind": {
+          "$ref": "#/definitions/ServiceKind"
+        },
+        "serviceTypeName": {
+          "type": "string",
+          "description": "The name of the service type"
+        },
+        "partitionDescription": {
+          "$ref": "#/definitions/Partition"
+        },
+        "servicePackageActivationMode": {
+          "type": "string",
+          "description": "The activation Mode of the service package",
+          "enum": [
+            "SharedProcess",
+            "ExclusiveProcess"
+          ],
+          "x-ms-enum": {
+            "name": "ServicePackageActivationMode",
+            "modelAsString": true,
+            "values": [
+              {
+                "value": "SharedProcess",
+                "description": "Indicates the application package activation mode will use shared process."
+              },
+              {
+                "value": "ExclusiveProcess",
+                "description": "Indicates the application package activation mode will use exclusive process."
+              }
+            ]
+          }
+        }
+      }
+    },
+    "ServiceResourcePropertiesBase": {
+      "description": "The common service resource properties.",
+      "properties": {
+        "placementConstraints": {
+          "type": "string",
+          "description": "The placement constraints as a string. Placement constraints are boolean expressions on node properties and allow for restricting a service to particular nodes based on the service requirements. For example, to place a service on nodes where NodeType is blue specify the following: \"NodeColor == blue)\"."
+        },
+        "correlationScheme": {
+          "$ref": "#/definitions/CorrelationSchemeList"
+        },
+        "serviceLoadMetrics": {
+          "$ref": "#/definitions/ServiceLoadMetricsList"
+        },
+        "servicePlacementPolicies": {
+          "$ref": "#/definitions/ServicePlacementPoliciesList"
+        },
+        "defaultMoveCost": {
+          "$ref": "#/definitions/MoveCost"
+        },
+        "scalingPolicies": {
+          "$ref": "#/definitions/ScalingPolicyList"
+        }
+      }
+    },
+    "ServiceScalingMechanismKind": {
+      "type": "string",
+      "description": "Enumerates the ways that a service can be partitioned.",
+      "enum": [
+        "ScalePartitionInstanceCount",
+        "AddRemoveIncrementalNamedPartition"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceScalingMechanismKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "ScalePartitionInstanceCount",
+            "description": "Represents a scaling mechanism for adding or removing instances of stateless service partition. The value is 0."
+          },
+          {
+            "value": "AddRemoveIncrementalNamedPartition",
+            "description": "Represents a scaling mechanism for adding or removing named partitions of a stateless service. The value is 1."
+          }
+        ]
+      }
+    },
+    "ServiceScalingTriggerKind": {
+      "type": "string",
+      "description": "Enumerates the ways that a service can be partitioned.",
+      "enum": [
+        "AveragePartitionLoad",
+        "AverageServiceLoad"
+      ],
+      "x-ms-enum": {
+        "name": "ServiceScalingTriggerKind",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "AveragePartitionLoad",
+            "description": "Represents a scaling trigger related to an average load of a metric/resource of a partition. The value is 0."
+          },
+          {
+            "value": "AverageServiceLoad",
+            "description": "Represents a scaling policy related to an average load of a metric/resource of a service. The value is 1."
+          }
+        ]
+      }
+    },
+    "ServiceTypeHealthPolicy": {
+      "type": "object",
+      "description": "Represents the health policy used to evaluate the health of services belonging to a service type.\n",
+      "required": [
+        "maxPercentUnhealthyServices",
+        "maxPercentUnhealthyPartitionsPerService",
+        "maxPercentUnhealthyReplicasPerPartition"
+      ],
+      "properties": {
+        "maxPercentUnhealthyServices": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum allowed percentage of unhealthy services.\n\nThe percentage represents the maximum tolerated percentage of services that can be unhealthy before the application is considered in error.\nIf the percentage is respected but there is at least one unhealthy service, the health is evaluated as Warning.\nThis is calculated by dividing the number of unhealthy services of the specific service type over the total number of services of the specific service type.\nThe computation rounds up to tolerate one failure on small numbers of services.\n",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "maxPercentUnhealthyPartitionsPerService": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum allowed percentage of unhealthy partitions per service.\n\nThe percentage represents the maximum tolerated percentage of partitions that can be unhealthy before the service is considered in error.\nIf the percentage is respected but there is at least one unhealthy partition, the health is evaluated as Warning.\nThe percentage is calculated by dividing the number of unhealthy partitions over the total number of partitions in the service.\nThe computation rounds up to tolerate one failure on small numbers of partitions.\n",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "maxPercentUnhealthyReplicasPerPartition": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The maximum allowed percentage of unhealthy replicas per partition.\n\nThe percentage represents the maximum tolerated percentage of replicas that can be unhealthy before the partition is considered in error.\nIf the percentage is respected but there is at least one unhealthy replica, the health is evaluated as Warning.\nThe percentage is calculated by dividing the number of unhealthy replicas over the total number of replicas in the partition.\nThe computation rounds up to tolerate one failure on small numbers of replicas.\n",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "ServiceTypeHealthPolicyMap": {
+      "type": "object",
+      "description": "Defines a ServiceTypeHealthPolicy per service type name.\n\nThe entries in the map replace the default service type health policy for each specified service type.\nFor example, in an application that contains both a stateless gateway service type and a stateful engine service type, the health policies for the stateless and stateful services can be configured differently.\nWith policy per service type, there's more granular control of the health of the service.\n\nIf no policy is specified for a service type name, the DefaultServiceTypeHealthPolicy is used for evaluation.\n",
+      "additionalProperties": {
+        "$ref": "#/definitions/ServiceTypeHealthPolicy"
+      }
+    },
+    "ServiceUpdateParameters": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Service update parameters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Service update request"
+    },
+    "SingletonPartitionScheme": {
+      "description": "Describes the partition scheme of a singleton-partitioned, or non-partitioned service.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Partition"
+        },
+        {
+          "type": "object",
+          "description": "SingletonPartitionScheme"
+        }
+      ],
+      "x-ms-discriminator-value": "Singleton"
+    },
+    "StatefulServiceProperties": {
+      "description": "The properties of a stateful service resource.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServiceResourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Stateful",
+      "properties": {
+        "hasPersistedState": {
+          "type": "boolean",
+          "description": "A flag indicating whether this is a persistent service which stores states on the local disk. If it is then the value of this property is true, if not it is false."
+        },
+        "targetReplicaSetSize": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "description": "The target replica set size as a number."
+        },
+        "minReplicaSetSize": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 1,
+          "description": "The minimum replica set size as a number."
+        },
+        "replicaRestartWaitDuration": {
+          "type": "string",
+          "description": "The duration between when a replica goes down and when a new replica is created, represented in ISO 8601 format \"hh:mm:ss\"."
+        },
+        "quorumLossWaitDuration": {
+          "type": "string",
+          "description": "The maximum duration for which a partition is allowed to be in a state of quorum loss, represented in ISO 8601 format \"hh:mm:ss\"."
+        },
+        "standByReplicaKeepDuration": {
+          "type": "string",
+          "description": "The definition on how long StandBy replicas should be maintained before being removed, represented in ISO 8601 format \"hh:mm:ss\"."
+        },
+        "servicePlacementTimeLimit": {
+          "type": "string",
+          "description": "The duration for which replicas can stay InBuild before reporting that build is stuck, represented in ISO 8601 format \"hh:mm:ss\"."
+        }
+      }
+    },
+    "StatelessServiceProperties": {
+      "description": "The properties of a stateless service resource.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/ServiceResourceProperties"
+        }
+      ],
+      "x-ms-discriminator-value": "Stateless",
+      "required": [
+        "instanceCount"
+      ],
+      "properties": {
+        "instanceCount": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": -1,
+          "description": "The instance count."
+        },
+        "minInstanceCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "MinInstanceCount is the minimum number of instances that must be up to meet the EnsureAvailability safety check during operations like upgrade or deactivate node. The actual number that is used is max( MinInstanceCount, ceil( MinInstancePercentage/100.0 * InstanceCount) ). Note, if InstanceCount is set to -1, during MinInstanceCount computation -1 is first converted into the number of nodes on which the instances are allowed to be placed according to the placement constraints on the service."
+        },
+        "minInstancePercentage": {
+          "type": "integer",
+          "format": "int32",
+          "description": "MinInstancePercentage is the minimum percentage of InstanceCount that must be up to meet the EnsureAvailability safety check during operations like upgrade or deactivate node. The actual number that is used is max( MinInstanceCount, ceil( MinInstancePercentage/100.0 * InstanceCount) ). Note, if InstanceCount is set to -1, during MinInstancePercentage computation, -1 is first converted into the number of nodes on which the instances are allowed to be placed according to the placement constraints on the service."
+        }
+      }
+    },
+    "UniformInt64RangePartitionScheme": {
+      "description": "Describes a partitioning scheme where an integer range is allocated evenly across a number of partitions.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Partition"
+        },
+        {
+          "type": "object",
+          "description": "UniformInt64RangePartitionScheme"
+        }
+      ],
+      "x-ms-discriminator-value": "UniformInt64Range",
+      "required": [
+        "count",
+        "lowKey",
+        "highKey"
+      ],
+      "properties": {
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of partitions."
+        },
+        "lowKey": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The lower bound of the partition key range that\nshould be split between the partition ‘Count’\n"
+        },
+        "highKey": {
+          "type": "integer",
+          "format": "int64",
+          "description": "The upper bound of the partition key range that\nshould be split between the partition ‘Count’\n"
+        }
+      }
+    },
+    "UpgradeDomainTimeout": {
+      "type": "string",
+      "description": "The amount of time each upgrade domain has to complete before FailureAction is executed. Cannot be larger than 12 hours. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
+    },
+    "UpgradeTimeout": {
+      "type": "string",
+      "description": "The amount of time the overall upgrade has to complete before FailureAction is executed. Cannot be larger than 12 hours. It is interpreted as a string representing an ISO 8601 duration with following format \"hh:mm:ss.fff\"."
+    },
+    "UserAssignedIdentity": {
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The principal id of user assigned identity."
+        },
+        "clientId": {
+          "type": "string",
+          "readOnly": true,
+          "description": "The client id of user assigned identity."
+        }
+      }
+    },
+    "UserAssignedIdentityMap": {
+      "type": "object",
+      "description": "The list of user identities associated with the resource. The user identity dictionary key references will be ARM resource ids in the form:\n'/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.\n",
+      "additionalProperties": {
+        "$ref": "#/definitions/UserAssignedIdentity"
+      }
+    },
+    "AvailableOperationDisplay": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The name of the provider."
+        },
+        "resource": {
+          "type": "string",
+          "description": "The resource on which the operation is performed"
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation that can be performed."
+        },
+        "description": {
+          "type": "string",
+          "description": "Operation description"
+        }
+      },
+      "description": "Operation supported by the Service Fabric resource provider"
+    },
+    "ErrorModel": {
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorModelError",
+          "description": "The error details."
+        }
+      },
+      "description": "The structure of the error."
+    },
+    "ErrorModelError": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message."
+        }
+      },
+      "description": "The error details."
+    },
+    "OperationResult": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the operation."
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "Indicates whether the operation is a data action"
+        },
+        "display": {
+          "$ref": "#/definitions/AvailableOperationDisplay",
+          "description": "The object that represents the operation."
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin result"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "Available operation list result"
+    },
+    "SystemData": {
+      "description": "Metadata pertaining to creation and last modification of the resource.",
+      "type": "object",
+      "readOnly": true,
+      "properties": {
+        "createdBy": {
+          "type": "string",
+          "description": "The identity that created the resource."
+        },
+        "createdByType": {
+          "type": "string",
+          "description": "The type of identity that created the resource."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource creation (UTC)."
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "The identity that last modified the resource."
+        },
+        "lastModifiedByType": {
+          "type": "string",
+          "description": "The type of identity that last modified the resource."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource last modification (UTC)."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The version of the Service Fabric resource provider API. This is a required parameter and it's value must be \"2021-05-01\" for this specification.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "2021-05-01"
+      ],
+      "x-ms-parameter-location": "client"
+    },
+    "applicationName": {
+      "name": "applicationName",
+      "in": "path",
+      "description": "The name of the application resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "applicationTypeName": {
+      "name": "applicationTypeName",
+      "in": "path",
+      "description": "The name of the application type name resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "clusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "description": "The name of the cluster resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "resourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "serviceName": {
+      "name": "serviceName",
+      "in": "path",
+      "description": "The name of the service resource in the format of {applicationName}~{serviceName}.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "subscriptionId": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The customer subscription identifier.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    },
+    "version": {
+      "name": "version",
+      "in": "path",
+      "description": "The application type version.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    }
+  }
+}

--- a/App_Data/SwaggerSpecs/Microsoft.ServiceFabricManagedClusters/managedcluster.json
+++ b/App_Data/SwaggerSpecs/Microsoft.ServiceFabricManagedClusters/managedcluster.json
@@ -1,0 +1,1411 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "ServiceFabricManagementClient",
+    "description": "Azure Service Fabric Resource Provider API Client",
+    "version": "2021-05-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      },
+      "type": "oauth2"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters": {
+      "get": {
+        "operationId": "ManagedClusters_ListByResourceGroup",
+        "summary": "Gets the list of Service Fabric cluster resources created in the specified resource group.",
+        "description": "Gets all Service Fabric cluster resources created or in the process of being created in the resource group.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "tags": [
+          "ManagedCluster"
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List cluster by resource group": {
+            "$ref": "./examples/ManagedClusterListByResourceGroupOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterListResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceFabric/managedClusters": {
+      "get": {
+        "operationId": "ManagedClusters_ListBySubscription",
+        "summary": "Gets the list of Service Fabric cluster resources created in the specified subscription.",
+        "description": "Gets all Service Fabric cluster resources created or in the process of being created in the subscription.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "tags": [
+          "ManagedCluster"
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List managed clusters": {
+            "$ref": "./examples/ManagedClusterListBySubscriptionOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterListResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}": {
+      "get": {
+        "tags": [
+          "ManagedCluster"
+        ],
+        "operationId": "ManagedClusters_Get",
+        "summary": "Gets a Service Fabric managed cluster resource.",
+        "description": "Get a Service Fabric managed cluster resource created or in the process of being created in the specified resource group.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "x-ms-examples": {
+          "Get a cluster": {
+            "$ref": "./examples/ManagedClusterGetOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "ManagedCluster"
+        ],
+        "operationId": "ManagedClusters_CreateOrUpdate",
+        "summary": "Creates or updates a Service Fabric managed cluster resource.",
+        "description": "Create or update a Service Fabric managed cluster resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The cluster resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Put a cluster with minimum parameters": {
+            "$ref": "./examples/ManagedClusterPutOperation_example_min.json"
+          },
+          "Put a cluster with maximum parameters": {
+            "$ref": "./examples/ManagedClusterPutOperation_example_max.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "ManagedCluster"
+        ],
+        "operationId": "ManagedClusters_Update",
+        "summary": "Updates the tags of of a Service Fabric managed cluster resource.",
+        "description": "Update the tags of of a Service Fabric managed cluster resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The managed cluster resource updated tags.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterUpdateParameters"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Patch a managed cluster": {
+            "$ref": "./examples/ManagedClusterPatchOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedCluster"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "ManagedCluster"
+        ],
+        "operationId": "ManagedClusters_Delete",
+        "summary": "Deletes a Service Fabric managed cluster resource.",
+        "description": "Delete a Service Fabric managed cluster resource with the specified name.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete a cluster": {
+            "$ref": "./examples/ManagedClusterDeleteOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The resource was not found."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceFabric/locations/{location}/managedClusterVersions/{clusterVersion}": {
+      "get": {
+        "operationId": "ManagedClusterVersion_Get",
+        "summary": "Gets information about a Service Fabric managed cluster code version available in the specified location.",
+        "description": "Gets information about an available Service Fabric managed cluster code version.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/locationForClusterCodeVersions"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/clusterVersion"
+          }
+        ],
+        "x-ms-examples": {
+          "Get cluster version": {
+            "$ref": "./examples/ManagedClusterVersionGet_example.json"
+          }
+        },
+        "tags": [
+          "ManagedClusterVersion"
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterCodeVersionResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceFabric/locations/{location}/environments/{environment}/managedClusterVersions/{clusterVersion}": {
+      "get": {
+        "operationId": "ManagedClusterVersion_GetByEnvironment",
+        "summary": "Gets information about a Service Fabric cluster code version available for the specified environment.",
+        "description": "Gets information about an available Service Fabric cluster code version by environment.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/locationForClusterCodeVersions"
+          },
+          {
+            "$ref": "#/parameters/environment"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/clusterVersion"
+          }
+        ],
+        "x-ms-examples": {
+          "Get cluster version by environment": {
+            "$ref": "./examples/ManagedClusterVersionGetByEnvironment_example.json"
+          }
+        },
+        "tags": [
+          "ManagedClusterVersion"
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterCodeVersionResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceFabric/locations/{location}/managedClusterVersions": {
+      "get": {
+        "operationId": "ManagedClusterVersion_List",
+        "summary": "Gets the list of Service Fabric cluster code versions available for the specified location.",
+        "description": "Gets all available code versions for Service Fabric cluster resources by location.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/locationForClusterCodeVersions"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "x-ms-examples": {
+          "List cluster versions": {
+            "$ref": "./examples/ManagedClusterVersionList_example.json"
+          }
+        },
+        "tags": [
+          "ManagedClusterVersion"
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterCodeVersionListResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/providers/Microsoft.ServiceFabric/locations/{location}/environments/{environment}/managedClusterVersions": {
+      "get": {
+        "operationId": "ManagedClusterVersion_ListByEnvironment",
+        "summary": "Gets the list of Service Fabric cluster code versions available for the specified environment.",
+        "description": "Gets all available code versions for Service Fabric cluster resources by environment.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/locationForClusterCodeVersions"
+          },
+          {
+            "$ref": "#/parameters/environment"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          }
+        ],
+        "x-ms-examples": {
+          "List cluster versions by environment": {
+            "$ref": "./examples/ManagedClusterVersionListByEnvironment.json"
+          }
+        },
+        "tags": [
+          "ManagedClusterVersion"
+        ],
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/ManagedClusterCodeVersionListResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/providers/Microsoft.ServiceFabric/operations": {
+      "get": {
+        "tags": [
+          "Operations"
+        ],
+        "summary": "Lists all of the available Service Fabric resource provider API operations.",
+        "description": "Get the list of available Service Fabric resource provider API operations.",
+        "operationId": "Operations_List",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "The version of the Service Fabric resource provider API",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "x-ms-examples": {
+          "List available operations": {
+            "$ref": "./examples/Operations_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK. The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ManagedClusterAddOnFeature": {
+      "type": "string",
+      "description": "Available cluster add-on features",
+      "enum": [
+        "DnsService",
+        "BackupRestoreService",
+        "ResourceMonitorService"
+      ]
+    },
+    "ApplicationTypeVersionsCleanupPolicy": {
+      "required": [
+        "maxUnusedVersionsToKeep"
+      ],
+      "properties": {
+        "maxUnusedVersionsToKeep": {
+          "type": "integer",
+          "format": "int32",
+          "minimum": 0,
+          "description": "Number of unused versions per application type to keep."
+        }
+      },
+      "description": "The policy used to clean up unused versions. When the policy is not specified explicitly, the default unused application versions to keep will be 3."
+    },
+    "AzureActiveDirectory": {
+      "properties": {
+        "tenantId": {
+          "type": "string",
+          "description": "Azure active directory tenant id."
+        },
+        "clusterApplication": {
+          "type": "string",
+          "description": "Azure active directory cluster application id."
+        },
+        "clientApplication": {
+          "type": "string",
+          "description": "Azure active directory client application id."
+        }
+      },
+      "description": "The settings to enable AAD authentication on the cluster."
+    },
+    "ClientCertificate": {
+      "required": [
+        "isAdmin"
+      ],
+      "properties": {
+        "isAdmin": {
+          "type": "boolean",
+          "description": "Indicates if the client certificate has admin access to the cluster. Non admin clients can perform only read only operations on the cluster."
+        },
+        "thumbprint": {
+          "type": "string",
+          "description": "Certificate thumbprint."
+        },
+        "commonName": {
+          "type": "string",
+          "description": "Certificate common name."
+        },
+        "issuerThumbprint": {
+          "type": "string",
+          "description": "Issuer thumbprint for the certificate. Only used together with CommonName."
+        }
+      },
+      "description": "Client certificate definition."
+    },
+    "ClusterState": {
+      "type": "string",
+      "description": "The current state of the cluster.\n",
+      "enum": [
+        "WaitingForNodes",
+        "Deploying",
+        "BaselineUpgrade",
+        "Upgrading",
+        "UpgradeFailed",
+        "Ready"
+      ],
+      "x-ms-enum": {
+        "name": "ClusterState",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "WaitingForNodes",
+            "description": "Indicates that the cluster resource is created and the resource provider is waiting for Service Fabric VM extension to boot up and report to it."
+          },
+          {
+            "value": "Deploying",
+            "description": "Indicates that the Service Fabric runtime is being installed on the VMs. Cluster resource will be in this state until the cluster boots up and system services are up."
+          },
+          {
+            "value": "BaselineUpgrade",
+            "description": "Indicates that the cluster is upgrading to establishes the cluster version. This upgrade is automatically initiated when the cluster boots up for the first time."
+          },
+          {
+            "value": "Upgrading",
+            "description": "Indicates that the cluster is being upgraded with the user provided configuration."
+          },
+          {
+            "value": "UpgradeFailed",
+            "description": "Indicates that the last upgrade for the cluster has failed."
+          },
+          {
+            "value": "Ready",
+            "description": "Indicates that the cluster is in a stable state."
+          }
+        ]
+      }
+    },
+    "ClusterUpgradeCadence": {
+      "type": "string",
+      "enum": [
+        "Wave0",
+        "Wave1",
+        "Wave2"
+      ],
+      "x-ms-enum": {
+        "name": "clusterUpgradeCadence",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Wave0",
+            "description": "Cluster upgrade starts immediately after a new version is rolled out. Recommended for Test/Dev clusters."
+          },
+          {
+            "value": "Wave1",
+            "description": "Cluster upgrade starts 7 days after a new version is rolled out. Recommended for Pre-prod clusters."
+          },
+          {
+            "value": "Wave2",
+            "description": "Cluster upgrade starts 14 days after a new version is rolled out. Recommended for Production clusters."
+          }
+        ]
+      },
+      "description": "Indicates when new cluster runtime version upgrades will be applied after they are released. By default is Wave0."
+    },
+    "ClusterUpgradeMode": {
+      "type": "string",
+      "description": "The upgrade mode of the cluster when new Service Fabric runtime version is available.\n",
+      "enum": [
+        "Automatic",
+        "Manual"
+      ],
+      "default": "Automatic",
+      "x-ms-enum": {
+        "name": "ClusterUpgradeMode",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Automatic",
+            "description": "The cluster will be automatically upgraded to the latest Service Fabric runtime version, **clusterUpgradeCadence** will determine when the upgrade starts after the new version becomes available."
+          },
+          {
+            "value": "Manual",
+            "description": "The cluster will not be automatically upgraded to the latest Service Fabric runtime version. The cluster is upgraded by setting the **clusterCodeVersion** property in the cluster resource."
+          }
+        ]
+      }
+    },
+    "LoadBalancingRule": {
+      "required": [
+        "frontendPort",
+        "backendPort",
+        "protocol",
+        "probeProtocol"
+      ],
+      "properties": {
+        "frontendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port for the external endpoint. Port numbers for each rule must be unique within the Load Balancer. Acceptable values are between 1 and 65534.",
+          "minimum": 1,
+          "maximum": 65534
+        },
+        "backendPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for internal connections on the endpoint. Acceptable values are between 1 and 65535.",
+          "minimum": 1,
+          "maximum": 65534
+        },
+        "protocol": {
+          "type": "string",
+          "description": "The reference to the transport protocol used by the load balancing rule.",
+          "enum": [
+            "tcp",
+            "udp"
+          ],
+          "x-ms-enum": {
+            "name": "protocol",
+            "modelAsString": true
+          }
+        },
+        "probePort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The prob port used by the load balancing rule. Acceptable values are between 1 and 65535.",
+          "minimum": 1,
+          "maximum": 65534
+        },
+        "probeProtocol": {
+          "type": "string",
+          "description": "the reference to the load balancer probe used by the load balancing rule.",
+          "enum": [
+            "tcp",
+            "http",
+            "https"
+          ],
+          "x-ms-enum": {
+            "name": "probeProtocol",
+            "modelAsString": true
+          }
+        },
+        "probeRequestPath": {
+          "type": "string",
+          "description": "The probe request path. Only supported for HTTP/HTTPS probes."
+        }
+      },
+      "description": "Describes a load balancing rule."
+    },
+    "ManagedCluster": {
+      "type": "object",
+      "description": "The manged cluster resource\n",
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        },
+        {
+          "type": "object"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ManagedClusterProperties",
+          "description": "The managed cluster resource properties"
+        },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "The sku of the managed cluster"
+        }
+      }
+    },
+    "ManagedClusterCodeVersionListResult": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ManagedClusterCodeVersionResult"
+      },
+      "description": "The list results of the Service Fabric runtime versions."
+    },
+    "ManagedClusterCodeVersionResult": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The identification of the result"
+        },
+        "name": {
+          "type": "string",
+          "description": "The name of the result"
+        },
+        "type": {
+          "type": "string",
+          "description": "The result resource type"
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/ManagedClusterVersionDetails"
+        }
+      },
+      "description": "The result of the Service Fabric runtime versions"
+    },
+    "ManagedClusterListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagedCluster"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "Managed Cluster list results"
+    },
+    "ManagedClusterProperties": {
+      "required": [
+        "dnsName",
+        "adminUserName"
+      ],
+      "properties": {
+        "dnsName": {
+          "type": "string",
+          "description": "The cluster dns name."
+        },
+        "fqdn": {
+          "type": "string",
+          "description": "The fully qualified domain name associated with the public load balancer of the cluster.",
+          "readOnly": true
+        },
+        "ipv4Address": {
+          "type": "string",
+          "description": "The IPv4 address associated with the public load balancer of the cluster.",
+          "readOnly": true
+        },
+        "clusterId": {
+          "type": "string",
+          "description": "A service generated unique identifier for the cluster resource.",
+          "readOnly": true
+        },
+        "clusterState": {
+          "readOnly": true,
+          "$ref": "#/definitions/ClusterState",
+          "description": "The current state of the cluster."
+        },
+        "clusterCertificateThumbprints": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "List of thumbprints of the cluster certificates.",
+          "readOnly": true
+        },
+        "clientConnectionPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for client connections to the cluster.",
+          "default": 19000
+        },
+        "httpGatewayConnectionPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The port used for HTTP connections to the cluster.",
+          "default": 19080
+        },
+        "adminUserName": {
+          "type": "string",
+          "description": "VM admin user name."
+        },
+        "adminPassword": {
+          "type": "string",
+          "x-ms-secret": true,
+          "format": "password",
+          "description": "VM admin user password."
+        },
+        "loadBalancingRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/LoadBalancingRule"
+          },
+          "description": "Load balancing rules that are applied to the public load balancer of the cluster."
+        },
+        "allowRdpAccess": {
+          "type": "boolean",
+          "description": "Setting this to true enables RDP access to the VM. The default NSG rule opens RDP port to internet which can be overridden with custom Network Security Rules. The default value for this setting is false."
+        },
+        "networkSecurityRules": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/NetworkSecurityRule"
+          },
+          "description": "Custom Network Security Rules that are applied to the virtual network of the cluster."
+        },
+        "clients": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ClientCertificate"
+          },
+          "description": "Client certificates that are allowed to manage the cluster."
+        },
+        "azureActiveDirectory": {
+          "$ref": "#/definitions/AzureActiveDirectory",
+          "description": "The AAD authentication settings of the cluster."
+        },
+        "fabricSettings": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/SettingsSectionDescription"
+          },
+          "description": "The list of custom fabric settings to configure the cluster."
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedResourceProvisioningState",
+          "readOnly": true,
+          "description": "The provisioning state of the managed cluster resource."
+        },
+        "clusterCodeVersion": {
+          "type": "string",
+          "description": "The Service Fabric runtime version of the cluster. This property is required when **clusterUpgradeMode** is set to 'Manual'. To get list of available Service Fabric versions for new clusters use [ClusterVersion API](./ClusterVersion.md). To get the list of available version for existing clusters use **availableClusterVersions**."
+        },
+        "clusterUpgradeMode": {
+          "$ref": "#/definitions/ClusterUpgradeMode"
+        },
+        "clusterUpgradeCadence": {
+          "$ref": "#/definitions/ClusterUpgradeCadence",
+          "description": "Indicates when new cluster runtime version upgrades will be applied after they are released. By default is Wave0. Only applies when **clusterUpgradeMode** is set to 'Automatic'."
+        },
+        "addonFeatures": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ManagedClusterAddOnFeature"
+          },
+          "description": "List of add-on features to enable on the cluster."
+        },
+        "enableAutoOSUpgrade": {
+          "type": "boolean",
+          "description": "Setting this to true enables automatic OS upgrade for the node types that are created using any platform OS image with version 'latest'. The default value for this setting is false."
+        },
+        "zonalResiliency": {
+          "type": "boolean",
+          "description": "Indicates if the cluster has zone resiliency.",
+          "default": false
+        },
+        "applicationTypeVersionsCleanupPolicy": {
+          "$ref": "#/definitions/ApplicationTypeVersionsCleanupPolicy",
+          "description": "The policy used to clean up unused versions."
+        }
+      },
+      "description": "Describes the managed cluster resource properties."
+    },
+    "ManagedClusterUpdateParameters": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Managed cluster update parameters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Managed cluster update request"
+    },
+    "ManagedClusterVersionDetails": {
+      "properties": {
+        "clusterCodeVersion": {
+          "type": "string",
+          "description": "The Service Fabric runtime version of the cluster."
+        },
+        "supportExpiryUtc": {
+          "type": "string",
+          "description": "The date of expiry of support of the version."
+        },
+        "osType": {
+          "$ref": "#/definitions/OsType"
+        }
+      },
+      "description": "The detail of the Service Fabric runtime version result"
+    },
+    "NetworkSecurityRule": {
+      "required": [
+        "name",
+        "protocol",
+        "access",
+        "priority",
+        "direction"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Network security rule name."
+        },
+        "description": {
+          "type": "string",
+          "description": "Network security rule description."
+        },
+        "protocol": {
+          "type": "string",
+          "description": "Network protocol this rule applies to.",
+          "enum": [
+            "http",
+            "https",
+            "tcp",
+            "udp",
+            "icmp",
+            "ah",
+            "esp"
+          ],
+          "x-ms-enum": {
+            "name": "nsgProtocol",
+            "modelAsString": true
+          }
+        },
+        "sourceAddressPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The CIDR or source IP ranges."
+        },
+        "destinationAddressPrefixes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The destination address prefixes. CIDR or destination IP ranges."
+        },
+        "sourcePortRanges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The source port ranges."
+        },
+        "destinationPortRanges": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "The destination port ranges."
+        },
+        "access": {
+          "type": "string",
+          "description": "The network traffic is allowed or denied.",
+          "enum": [
+            "allow",
+            "deny"
+          ],
+          "x-ms-enum": {
+            "name": "access",
+            "modelAsString": true
+          }
+        },
+        "priority": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The priority of the rule. The value can be in the range 1000 to 3000. Values outside this range are reserved for Service Fabric ManagerCluster Resource Provider. The priority number must be unique for each rule in the collection. The lower the priority number, the higher the priority of the rule.",
+          "minimum": 1000,
+          "maximum": 3000
+        },
+        "direction": {
+          "type": "string",
+          "description": "Network security rule direction.",
+          "enum": [
+            "inbound",
+            "outbound"
+          ],
+          "x-ms-enum": {
+            "name": "direction",
+            "modelAsString": true
+          }
+        }
+      },
+      "description": "Describes a network security rule."
+    },
+    "OsType": {
+      "type": "string",
+      "description": "Cluster operating system, the default will be Windows",
+      "enum": [
+        "Windows"
+      ]
+    },
+    "Sku": {
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/definitions/SkuName",
+          "description": "Sku Name."
+        }
+      },
+      "description": "Service Fabric managed cluster Sku definition"
+    },
+    "SkuName": {
+      "type": "string",
+      "description": "Sku Name.",
+      "enum": [
+        "Basic",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "SkuName",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Basic",
+            "description": "Basic requires a minimum of 3 nodes and allows only 1 node type."
+          },
+          {
+            "value": "Standard",
+            "description": "Requires a minimum of 5 nodes and allows 1 or more node type."
+          }
+        ]
+      }
+    },
+    "AvailableOperationDisplay": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The name of the provider."
+        },
+        "resource": {
+          "type": "string",
+          "description": "The resource on which the operation is performed"
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation that can be performed."
+        },
+        "description": {
+          "type": "string",
+          "description": "Operation description"
+        }
+      },
+      "description": "Operation supported by the Service Fabric resource provider"
+    },
+    "ErrorModel": {
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorModelError",
+          "description": "The error details."
+        }
+      },
+      "description": "The structure of the error."
+    },
+    "ErrorModelError": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message."
+        }
+      },
+      "description": "The error details."
+    },
+    "ManagedResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the managed resource.",
+      "enum": [
+        "None",
+        "Creating",
+        "Created",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting",
+        "Deleted",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedResourceProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "OperationListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "description": "List of operations supported by the Service Fabric resource provider.",
+          "items": {
+            "$ref": "#/definitions/OperationResult"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "URL to get the next set of operation list results if there are any.",
+          "readOnly": true
+        }
+      },
+      "description": "Describes the result of the request to list Service Fabric resource provider operations."
+    },
+    "OperationResult": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the operation."
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "Indicates whether the operation is a data action"
+        },
+        "display": {
+          "$ref": "#/definitions/AvailableOperationDisplay",
+          "description": "The object that represents the operation."
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin result"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "Available operation list result"
+    },
+    "Resource": {
+      "required": [
+        "location"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure resource identifier.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Azure resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Azure resource type.",
+          "readOnly": true
+        },
+        "location": {
+          "type": "string",
+          "description": "Azure resource location.",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        },
+        "tags": {
+          "type": "object",
+          "description": "Azure resource tags.",
+          "additionalProperties": {
+            "type": "string"
+          }
+        },
+        "etag": {
+          "type": "string",
+          "description": "Azure resource etag.",
+          "readOnly": true
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData"
+        }
+      },
+      "description": "The resource model definition.",
+      "x-ms-azure-resource": true
+    },
+    "SettingsParameterDescription": {
+      "required": [
+        "name",
+        "value"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The parameter name of fabric setting."
+        },
+        "value": {
+          "type": "string",
+          "description": "The parameter value of fabric setting."
+        }
+      },
+      "description": "Describes a parameter in fabric settings of the cluster."
+    },
+    "SettingsSectionDescription": {
+      "required": [
+        "name",
+        "parameters"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The section name of the fabric settings."
+        },
+        "parameters": {
+          "type": "array",
+          "description": "The collection of parameters in the section.",
+          "items": {
+            "$ref": "#/definitions/SettingsParameterDescription"
+          }
+        }
+      },
+      "description": "Describes a section in the fabric settings of the cluster."
+    },
+    "SystemData": {
+      "description": "Metadata pertaining to creation and last modification of the resource.",
+      "type": "object",
+      "readOnly": true,
+      "properties": {
+        "createdBy": {
+          "type": "string",
+          "description": "The identity that created the resource."
+        },
+        "createdByType": {
+          "type": "string",
+          "description": "The type of identity that created the resource."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource creation (UTC)."
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "The identity that last modified the resource."
+        },
+        "lastModifiedByType": {
+          "type": "string",
+          "description": "The type of identity that last modified the resource."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource last modification (UTC)."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The version of the Service Fabric resource provider API. This is a required parameter and it's value must be \"2021-05-01\" for this specification.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "2021-05-01"
+      ],
+      "x-ms-parameter-location": "client"
+    },
+    "clusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "description": "The name of the cluster resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "clusterVersion": {
+      "name": "clusterVersion",
+      "in": "path",
+      "description": "The cluster code version.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "environment": {
+      "name": "environment",
+      "in": "path",
+      "description": "The operating system of the cluster. The default means all.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "Windows"
+      ],
+      "x-ms-parameter-location": "method"
+    },
+    "locationForClusterCodeVersions": {
+      "name": "location",
+      "in": "path",
+      "description": "The location for the cluster code versions. This is different from cluster location.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "resourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "subscriptionId": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The customer subscription identifier.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    }
+  }
+}

--- a/App_Data/SwaggerSpecs/Microsoft.ServiceFabricManagedClusters/nodetype.json
+++ b/App_Data/SwaggerSpecs/Microsoft.ServiceFabricManagedClusters/nodetype.json
@@ -1,0 +1,1029 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "ServiceFabricManagementClient",
+    "description": "Azure Service Fabric Resource Provider API Client",
+    "version": "2021-05-01"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      },
+      "type": "oauth2"
+    }
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourcegroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes": {
+      "get": {
+        "operationId": "NodeTypes_ListByManagedClusters",
+        "summary": "Gets the list of Node types of the specified managed cluster.",
+        "description": "Gets all Node types of the specified managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "tags": [
+          "NodeType"
+        ],
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        },
+        "x-ms-examples": {
+          "List node type of the specified managed cluster": {
+            "$ref": "./examples/NodeTypeListOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NodeTypeListResult"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/restart": {
+      "post": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_Restart",
+        "summary": "Restarts one or more nodes on the node type.",
+        "description": "Restarts one or more nodes on the node type. It will disable the fabric nodes, trigger a restart on the VMs and activate the nodes back again.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "parameters for restart action.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NodeTypeActionParameters"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Restart nodes": {
+            "$ref": "./examples/RestartNodes_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/reimage": {
+      "post": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_Reimage",
+        "summary": "Reimages one or more nodes on the node type.",
+        "description": "Reimages one or more nodes on the node type. It will disable the fabric nodes, trigger a reimage on the VMs and activate the nodes back again.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "parameters for reimage action.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NodeTypeActionParameters"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Reimage nodes": {
+            "$ref": "./examples/ReimageNodes_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}/deleteNode": {
+      "post": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_DeleteNode",
+        "summary": "Deletes one or more nodes on the node type.",
+        "description": "Deletes one or more nodes on the node type. It will disable the fabric nodes, trigger a delete on the VMs and removes the state from the cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "parameters for delete action.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NodeTypeActionParameters"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete nodes": {
+            "$ref": "./examples/DeleteNodes_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ServiceFabric/managedClusters/{clusterName}/nodeTypes/{nodeTypeName}": {
+      "get": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_Get",
+        "summary": "Gets a Service Fabric node type.",
+        "description": "Get a Service Fabric node type of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Get a node type": {
+            "$ref": "./examples/NodeTypeGetOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NodeType"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_CreateOrUpdate",
+        "summary": "Creates or updates a Service Fabric node type.",
+        "description": "Create or update a Service Fabric node type of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The node type resource.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NodeType"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Put a node type with minimum parameters": {
+            "$ref": "./examples/NodeTypePutOperation_example_min.json"
+          },
+          "Put a node type with maximum parameters": {
+            "$ref": "./examples/NodeTypePutOperation_example_max.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NodeType"
+            }
+          },
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously.",
+            "schema": {
+              "$ref": "#/definitions/NodeType"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_Update",
+        "summary": "Update the tags of a node type resource of a given managed cluster.",
+        "description": "Update the configuration of a node type of a given managed cluster, only updating tags.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          },
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "The parameters to update the node type configuration.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/NodeTypeUpdateParameters"
+            },
+            "x-ms-parameter-location": "method"
+          }
+        ],
+        "x-ms-examples": {
+          "Patch a node type": {
+            "$ref": "./examples/NodeTypePatchOperation_example.json"
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "The operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/NodeType"
+            }
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "NodeType"
+        ],
+        "operationId": "NodeTypes_Delete",
+        "summary": "Deletes a Service Fabric node type.",
+        "description": "Delete a Service Fabric node type of a given managed cluster.",
+        "parameters": [
+          {
+            "$ref": "#/parameters/subscriptionId"
+          },
+          {
+            "$ref": "#/parameters/resourceGroupNameParameter"
+          },
+          {
+            "$ref": "#/parameters/clusterNameParameter"
+          },
+          {
+            "$ref": "#/parameters/nodeTypeNameParameter"
+          },
+          {
+            "$ref": "#/parameters/api-version"
+          }
+        ],
+        "x-ms-examples": {
+          "Delete a node type": {
+            "$ref": "./examples/NodeTypeDeleteOperation_example.json"
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "responses": {
+          "202": {
+            "description": "The request was accepted and the operation will complete asynchronously."
+          },
+          "204": {
+            "description": "The resource was not found."
+          },
+          "200": {
+            "description": "The operation completed successfully."
+          },
+          "default": {
+            "description": "The detailed error response.",
+            "schema": {
+              "$ref": "#/definitions/ErrorModel"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "DiskType": {
+      "type": "string",
+      "description": "Managed data disk type. IOPS and throughput are given by the disk size, to see more information go to https://docs.microsoft.com/en-us/azure/virtual-machines/disks-types.\n",
+      "enum": [
+        "Standard_LRS",
+        "StandardSSD_LRS",
+        "Premium_LRS"
+      ],
+      "default": "StandardSSD_LRS",
+      "x-ms-enum": {
+        "name": "DiskType",
+        "modelAsString": true,
+        "values": [
+          {
+            "value": "Standard_LRS",
+            "description": "Standard HDD locally redundant storage. Best for backup, non-critical, and infrequent access."
+          },
+          {
+            "value": "StandardSSD_LRS",
+            "description": "Standard SSD locally redundant storage. Best for web servers, lightly used enterprise applications and dev/test."
+          },
+          {
+            "value": "Premium_LRS",
+            "description": "Premium SSD locally redundant storage. Best for production and performance sensitive workloads."
+          }
+        ]
+      }
+    },
+    "ManagedProxyResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure resource identifier.",
+          "readOnly": true
+        },
+        "name": {
+          "type": "string",
+          "description": "Azure resource name.",
+          "readOnly": true
+        },
+        "type": {
+          "type": "string",
+          "description": "Azure resource type.",
+          "readOnly": true
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Azure resource tags.",
+          "x-ms-mutability": [
+            "create",
+            "read"
+          ]
+        },
+        "systemData": {
+          "$ref": "#/definitions/SystemData"
+        }
+      },
+      "description": "The resource model definition for proxy-only resource.",
+      "x-ms-azure-resource": true
+    },
+    "NodeType": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/ManagedProxyResource"
+        }
+      ],
+      "properties": {
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/NodeTypeProperties",
+          "description": "The node type properties"
+        }
+      },
+      "description": "Describes a node type in the cluster, each node type represents sub set of nodes in the cluster."
+    },
+    "NodeTypeActionParameters": {
+      "required": [
+        "nodes"
+      ],
+      "properties": {
+        "nodes": {
+          "description": "List of node names from the node type.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "force": {
+          "description": "Force the action to go through.",
+          "type": "boolean"
+        }
+      },
+      "description": "Parameters for Node type action."
+    },
+    "NodeTypeProperties": {
+      "required": [
+        "isPrimary",
+        "vmInstanceCount",
+        "dataDiskSizeGB"
+      ],
+      "properties": {
+        "isPrimary": {
+          "type": "boolean",
+          "description": "The node type on which system services will run. Only one node type should be marked as primary. Primary node type cannot be deleted or changed for existing clusters."
+        },
+        "vmInstanceCount": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of nodes in the node type.",
+          "minimum": 1,
+          "maximum": 2147483647
+        },
+        "dataDiskSizeGB": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Disk size for each vm in the node type in GBs."
+        },
+        "dataDiskType": {
+          "$ref": "#/definitions/DiskType"
+        },
+        "placementProperties": {
+          "type": "object",
+          "description": "The placement tags applied to nodes in the node type, which can be used to indicate where certain services (workload) should run.",
+          "additionalProperties": {
+            "type": "string",
+            "description": "Placement tag value"
+          }
+        },
+        "capacities": {
+          "type": "object",
+          "description": "The capacity tags applied to the nodes in the node type, the cluster resource manager uses these tags to understand how much resource a node has.",
+          "additionalProperties": {
+            "type": "string",
+            "description": "Capacity tag value"
+          }
+        },
+        "applicationPorts": {
+          "$ref": "#/definitions/EndpointRangeDescription",
+          "description": "The range of ports from which cluster assigned port to Service Fabric applications."
+        },
+        "ephemeralPorts": {
+          "$ref": "#/definitions/EndpointRangeDescription",
+          "description": "The range of ephemeral ports that nodes in this node type should be configured with."
+        },
+        "vmSize": {
+          "type": "string",
+          "description": "The size of virtual machines in the pool. All virtual machines in a pool are the same size. For example, Standard_D3."
+        },
+        "vmImagePublisher": {
+          "type": "string",
+          "description": "The publisher of the Azure Virtual Machines Marketplace image. For example, Canonical or MicrosoftWindowsServer."
+        },
+        "vmImageOffer": {
+          "type": "string",
+          "description": "The offer type of the Azure Virtual Machines Marketplace image. For example, UbuntuServer or WindowsServer."
+        },
+        "vmImageSku": {
+          "type": "string",
+          "description": "The SKU of the Azure Virtual Machines Marketplace image. For example, 14.04.0-LTS or 2012-R2-Datacenter."
+        },
+        "vmImageVersion": {
+          "type": "string",
+          "description": "The version of the Azure Virtual Machines Marketplace image. A value of 'latest' can be specified to select the latest version of an image. If omitted, the default is 'latest'."
+        },
+        "vmSecrets": {
+          "type": "array",
+          "title": "virtual machine secretes.",
+          "description": "The secrets to install in the virtual machines.",
+          "items": {
+            "$ref": "#/definitions/VaultSecretGroup"
+          }
+        },
+        "vmExtensions": {
+          "type": "array",
+          "title": "virtual machine extensions.",
+          "description": "Set of extensions that should be installed onto the virtual machines.",
+          "items": {
+            "$ref": "#/definitions/VMSSExtension"
+          }
+        },
+        "vmManagedIdentity": {
+          "$ref": "#/definitions/VmManagedIdentity"
+        },
+        "isStateless": {
+          "type": "boolean",
+          "description": "Indicates if the node type can only host Stateless workloads.",
+          "default": false
+        },
+        "multiplePlacementGroups": {
+          "type": "boolean",
+          "description": "Indicates if scale set associated with the node type can be composed of multiple placement groups.",
+          "default": false
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/ManagedResourceProvisioningState",
+          "readOnly": true,
+          "description": "The provisioning state of the managed cluster resource."
+        }
+      },
+      "description": "Describes a node type in the cluster, each node type represents sub set of nodes in the cluster."
+    },
+    "NodeTypeListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "title": "node type list value.",
+          "description": "The list of node types.",
+          "items": {
+            "$ref": "#/definitions/NodeType"
+          }
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "Node type list results"
+    },
+    "NodeTypeUpdateParameters": {
+      "properties": {
+        "tags": {
+          "type": "object",
+          "description": "Node type update parameters",
+          "additionalProperties": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Node type update request"
+    },
+    "SubResource": {
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Azure resource identifier."
+        }
+      },
+      "description": "Azure resource identifier.",
+      "x-ms-azure-resource": true
+    },
+    "VaultCertificate": {
+      "required": [
+        "certificateUrl",
+        "certificateStore"
+      ],
+      "properties": {
+        "certificateUrl": {
+          "type": "string",
+          "description": "This is the URL of a certificate that has been uploaded to Key Vault as a secret. For adding a secret to the Key Vault, see [Add a key or secret to the key vault](https://docs.microsoft.com/azure/key-vault/key-vault-get-started/#add). In this case, your certificate needs to be It is the Base64 encoding of the following JSON Object which is encoded in UTF-8: <br><br> {<br>  \"data\":\"<Base64-encoded-certificate>\",<br>  \"dataType\":\"pfx\",<br>  \"password\":\"<pfx-file-password>\"<br>}"
+        },
+        "certificateStore": {
+          "type": "string",
+          "description": "For Windows VMs, specifies the certificate store on the Virtual Machine to which the certificate should be added. The specified certificate store is implicitly in the LocalMachine account. <br><br>For Linux VMs, the certificate file is placed under the /var/lib/waagent directory, with the file name <UppercaseThumbprint>.crt for the X509 certificate file and <UppercaseThumbprint>.prv for private key. Both of these files are .pem formatted."
+        }
+      },
+      "description": "Describes a single certificate reference in a Key Vault, and where the certificate should reside on the VM."
+    },
+    "VaultSecretGroup": {
+      "required": [
+        "sourceVault",
+        "vaultCertificates"
+      ],
+      "properties": {
+        "sourceVault": {
+          "$ref": "#/definitions/SubResource",
+          "description": "The relative URL of the Key Vault containing all of the certificates in VaultCertificates."
+        },
+        "vaultCertificates": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/VaultCertificate"
+          },
+          "description": "The list of key vault references in SourceVault which contain certificates."
+        }
+      },
+      "description": "Specifies set of certificates that should be installed onto the virtual machines."
+    },
+    "VmManagedIdentity": {
+      "properties": {
+        "userAssignedIdentities": {
+          "type": "array",
+          "description": "The list of user identities associated with the virtual machine scale set under the node type. Each entry will be an ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}'.",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Identities for the virtual machine scale set under the node type."
+    },
+    "VMSSExtension": {
+      "required": [
+        "name",
+        "properties"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the extension."
+        },
+        "properties": {
+          "x-ms-client-flatten": true,
+          "$ref": "#/definitions/VMSSExtensionProperties",
+          "description": "Describes the properties of a Virtual Machine Scale Set Extension."
+        }
+      },
+      "description": "Specifies set of extensions that should be installed onto the virtual machines."
+    },
+    "VMSSExtensionProperties": {
+      "required": [
+        "publisher",
+        "type",
+        "typeHandlerVersion"
+      ],
+      "properties": {
+        "publisher": {
+          "type": "string",
+          "description": "The name of the extension handler publisher."
+        },
+        "type": {
+          "type": "string",
+          "description": "Specifies the type of the extension; an example is \"CustomScriptExtension\"."
+        },
+        "typeHandlerVersion": {
+          "type": "string",
+          "description": "Specifies the version of the script handler."
+        },
+        "autoUpgradeMinorVersion": {
+          "type": "boolean",
+          "description": "Indicates whether the extension should use a newer minor version if one is available at deployment time. Once deployed, however, the extension will not upgrade minor versions unless redeployed, even with this property set to true."
+        },
+        "settings": {
+          "type": "object",
+          "description": "Json formatted public settings for the extension."
+        },
+        "protectedSettings": {
+          "type": "object",
+          "description": "The extension can contain either protectedSettings or protectedSettingsFromKeyVault or no protected settings at all."
+        },
+        "forceUpdateTag": {
+          "type": "string",
+          "description": "If a value is provided and is different from the previous value, the extension handler will be forced to update even if the extension configuration has not changed."
+        },
+        "provisionAfterExtensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Collection of extension names after which this extension needs to be provisioned."
+        },
+        "provisioningState": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The provisioning state, which only appears in the response."
+        }
+      },
+      "description": "Describes the properties of a Virtual Machine Scale Set Extension."
+    },
+    "AvailableOperationDisplay": {
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "The name of the provider."
+        },
+        "resource": {
+          "type": "string",
+          "description": "The resource on which the operation is performed"
+        },
+        "operation": {
+          "type": "string",
+          "description": "The operation that can be performed."
+        },
+        "description": {
+          "type": "string",
+          "description": "Operation description"
+        }
+      },
+      "description": "Operation supported by the Service Fabric resource provider"
+    },
+    "EndpointRangeDescription": {
+      "required": [
+        "endPort",
+        "startPort"
+      ],
+      "properties": {
+        "startPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Starting port of a range of ports"
+        },
+        "endPort": {
+          "type": "integer",
+          "format": "int32",
+          "description": "End port of a range of ports"
+        }
+      },
+      "description": "Port range details"
+    },
+    "ErrorModel": {
+      "properties": {
+        "error": {
+          "$ref": "#/definitions/ErrorModelError",
+          "description": "The error details."
+        }
+      },
+      "description": "The structure of the error."
+    },
+    "ErrorModelError": {
+      "properties": {
+        "code": {
+          "type": "string",
+          "description": "The error code."
+        },
+        "message": {
+          "type": "string",
+          "description": "The error message."
+        }
+      },
+      "description": "The error details."
+    },
+    "ManagedResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of the managed resource.",
+      "enum": [
+        "None",
+        "Creating",
+        "Created",
+        "Updating",
+        "Succeeded",
+        "Failed",
+        "Canceled",
+        "Deleting",
+        "Deleted",
+        "Other"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedResourceProvisioningState",
+        "modelAsString": true
+      }
+    },
+    "OperationResult": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the operation."
+        },
+        "isDataAction": {
+          "type": "boolean",
+          "description": "Indicates whether the operation is a data action"
+        },
+        "display": {
+          "$ref": "#/definitions/AvailableOperationDisplay",
+          "description": "The object that represents the operation."
+        },
+        "origin": {
+          "type": "string",
+          "description": "Origin result"
+        },
+        "nextLink": {
+          "type": "string",
+          "description": "The URL to use for getting the next set of results."
+        }
+      },
+      "description": "Available operation list result"
+    },
+    "SystemData": {
+      "description": "Metadata pertaining to creation and last modification of the resource.",
+      "type": "object",
+      "readOnly": true,
+      "properties": {
+        "createdBy": {
+          "type": "string",
+          "description": "The identity that created the resource."
+        },
+        "createdByType": {
+          "type": "string",
+          "description": "The type of identity that created the resource."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource creation (UTC)."
+        },
+        "lastModifiedBy": {
+          "type": "string",
+          "description": "The identity that last modified the resource."
+        },
+        "lastModifiedByType": {
+          "type": "string",
+          "description": "The type of identity that last modified the resource."
+        },
+        "lastModifiedAt": {
+          "type": "string",
+          "format": "date-time",
+          "description": "The timestamp of resource last modification (UTC)."
+        }
+      }
+    }
+  },
+  "parameters": {
+    "api-version": {
+      "name": "api-version",
+      "in": "query",
+      "description": "The version of the Service Fabric resource provider API. This is a required parameter and it's value must be \"2021-05-01\" for this specification.",
+      "required": true,
+      "type": "string",
+      "enum": [
+        "2021-05-01"
+      ],
+      "x-ms-parameter-location": "client"
+    },
+    "clusterNameParameter": {
+      "name": "clusterName",
+      "in": "path",
+      "description": "The name of the cluster resource.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "nodeTypeNameParameter": {
+      "name": "nodeTypeName",
+      "in": "path",
+      "description": "The name of the node type.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "resourceGroupNameParameter": {
+      "name": "resourceGroupName",
+      "in": "path",
+      "description": "The name of the resource group.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "method"
+    },
+    "subscriptionId": {
+      "name": "subscriptionId",
+      "in": "path",
+      "description": "The customer subscription identifier.",
+      "required": true,
+      "type": "string",
+      "x-ms-parameter-location": "client"
+    }
+  }
+}


### PR DESCRIPTION
Add swagger specs for new service fabric offering: Service Fabric managed clusters.

Includes:
- Managed Applications
- Managed Clusters
- Nodetypes

Swagger spec: https://github.com/Azure/azure-rest-api-specs/tree/master/specification/servicefabricmanagedclusters/resource-manager/Microsoft.ServiceFabricManagedClusters/stable/2021-05-01