### PR TITLE
Add support for GET requests at /list resources

### DIFF
--- a/ng/AppStart/ResourceDefinitionCollection.ts
+++ b/ng/AppStart/ResourceDefinitionCollection.ts
@@ -166,7 +166,10 @@
             // handle resources that has a "secure GET"
             this.setParent(url, "GETPOST", operation.RequestBody, operation.RequestBodyDoc, operation.ApiVersion);
             return addedElement;
-        } else if (operation && (operation.MethodName.startsWith("Create") || operation.MethodName.startsWith("BeginCreate") || operation.MethodName.startsWith("Put")) && operation.HttpMethod === "PUT") {
+        } else if(resourceName == "list" && operation && operation.HttpMethod == "GET") {
+            this.setParent(url, "GETLIST", operation.RequestBody, operation.RequestBodyDoc, operation.ApiVersion);
+            return addedElement;
+        }else if (operation && (operation.MethodName.startsWith("Create") || operation.MethodName.startsWith("BeginCreate") || operation.MethodName.startsWith("Put")) && operation.HttpMethod === "PUT") {
             // handle resources that has a CreateOrUpdate
             this.setParent(url, "CREATE", operation.RequestBody, operation.RequestBodyDoc);
             if (operation.MethodName.indexOf("Updat") === -1) {

--- a/ng/models/ResourceDefinition.ts
+++ b/ng/models/ResourceDefinition.ts
@@ -10,9 +10,16 @@
     resourceName: string;
     query?: string[];
 
-
-    getGetActions(): string[] {
-        return this.actions.filter(a => (a === "GET" || a === "GETPOST"));
+    getGetAction(): string | undefined {
+        if (this.actions.includes("GET")) {
+            return "GET";
+        } else if (this.actions.includes("GETPOST")) {
+            return "GETPOST";
+        } else if (this.actions.includes("GETLIST")) {
+            return "GETLIST";
+        } else {
+            return undefined;
+        }
     }
 
     hasCreateAction(): boolean {

--- a/ng/models/TreeBranch.ts
+++ b/ng/models/TreeBranch.ts
@@ -21,17 +21,17 @@
 
 
     getGetHttpConfig(): ng.IRequestConfig {
-        const getActions = this.resourceDefinition.getGetActions();
+        const getAction = this.resourceDefinition.getGetAction();
         let httpConfig = null;
 
-        if (getActions.length === 1) {
-            const getAction = (getActions[0] === "GETPOST" ? "POST" : "GET");
+        if (getAction !== undefined) {
+            const method = (getAction === "GETPOST" ? "POST" : "GET");
             httpConfig = {
                 method: "POST",
                 url: "api/operations",
                 data: {
-                    Url: (getAction === "POST" ? this.elementUrl + "/list" : this.elementUrl),
-                    HttpMethod: getAction,
+                    Url: (getAction === "GETPOST" || getAction === "GETLIST" ? this.elementUrl + "/list" : this.elementUrl),
+                    HttpMethod: method,
                     ApiVersion: this.resourceDefinition.apiVersion
                 }
             };
@@ -40,10 +40,10 @@
     }
 
     getGetActionUrl(): string {
-        const getActions = this.resourceDefinition.getGetActions();
+        const getAction = this.resourceDefinition.getGetAction();
         let getActionUrl = null;
-        if (getActions.length === 1) {
-            if (getActions[0] === "GETPOST") {
+        if (getAction !== undefined) {
+            if (getAction === "GETPOST" || getAction == "GETLIST") {
                 getActionUrl = this.elementUrl + "/list";
             } else {
                 getActionUrl = this.elementUrl;


### PR DESCRIPTION
The AuthSettingsV2 resource under Microsoft.Web/sites has its GET method
at the /list resource. Currently resource explorer only supports GET at
/ or POST at /list. This PR expands to support /list GET requests.

In the case of multiple "GET" actions supported, we prioritize in the
following order to maintain backwards compatibility with existing
workflows:

1. GET at /
2. POST at /list
3. GET at /list