### PR TITLE
Rev autoscale api version 2022-10-01

### DIFF
--- a/App_Data/SwaggerSpecs/Microsoft.Insights/autoscale_API.json
+++ b/App_Data/SwaggerSpecs/Microsoft.Insights/autoscale_API.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "title": "MonitorManagementClient",
-    "version": "2015-04-01"
+    "version": "2022-10-01"
   },
   "host": "management.azure.com",
   "schemes": [


### PR DESCRIPTION
Update swagger api version for autoscale to 2022-10-01

Swagger spec: https://github.com/Azure/azure-rest-api-specs/blob/main/specification/monitor/resource-manager/Microsoft.Insights/stable/2022-10-01/autoscale_API.json